### PR TITLE
ATA-5275: Add RPC to request last synced block

### DIFF
--- a/prism-backend/node/src/main/scala/io/iohk/atala/prism/node/NodeServiceImpl.scala
+++ b/prism-backend/node/src/main/scala/io/iohk/atala/prism/node/NodeServiceImpl.scala
@@ -354,6 +354,22 @@ class NodeServiceImpl(
     }
   }
 
+  override def getLastSyncedBlockTimestamp(
+      request: node_api.GetLastSyncedBlockTimestampRequest
+  ): Future[node_api.GetLastSyncedBlockTimestampResponse] = {
+    val methodName = "lastSyncedTimestamp"
+    measureRequestFuture(serviceName, methodName)(
+      withLog(methodName, request) { _ =>
+        objectManagement.getLastSyncedTimestamp
+          .map { lastSyncedBlockTimestamp =>
+            node_api
+              .GetLastSyncedBlockTimestampResponse()
+              .withLastSyncedBlockTimestamp(lastSyncedBlockTimestamp.toProtoTimestamp)
+          }
+      }
+    )
+  }
+
   override def getNodeBuildInfo(
       request: node_api.GetNodeBuildInfoRequest
   ): Future[node_api.GetNodeBuildInfoResponse] = {

--- a/prism-backend/node/src/test/scala/io/iohk/atala/prism/node/NodeServiceSpec.scala
+++ b/prism-backend/node/src/test/scala/io/iohk/atala/prism/node/NodeServiceSpec.scala
@@ -343,6 +343,20 @@ class NodeServiceSpec
     }
   }
 
+  "NodeService.getLastSyncedBlockTimestamp" should {
+    "return the timestamp of the last synced block" in {
+      doReturn(Future.successful(dummySyncTimestamp))
+        .when(objectManagementService)
+        .getLastSyncedTimestamp
+
+      val response = service.getLastSyncedBlockTimestamp(
+        GetLastSyncedBlockTimestampRequest()
+      )
+
+      response.lastSyncedBlockTimestamp.value must be(dummySyncTimestamp.toProtoTimestamp)
+    }
+  }
+
   "NodeService.getOperationInfo" should {
     "return OPERATION_UNKNOWN when operation identifier was not found" in {
       val validOperation = BlockProcessingServiceSpec.signOperation(

--- a/prism-sdk/protos/src/node_api.proto
+++ b/prism-sdk/protos/src/node_api.proto
@@ -53,6 +53,13 @@ service NodeService {
      */
     rpc FlushOperationsBuffer(FlushOperationsBufferRequest) returns (FlushOperationsBufferResponse) {}
 
+    /**
+     * PUBLIC
+     *
+     * Retrieve the timestamp of the latest synchronized (processed by PRISM Node) block.
+     */
+    rpc GetLastSyncedBlockTimestamp(GetLastSyncedBlockTimestampRequest) returns (GetLastSyncedBlockTimestampResponse) {}
+
     // Publishes a sequence of signed operations in a single underlying transaction.
     // The sequence of operations has a size limit to fit in the metadata of the transaction (approx. 15KB).
     rpc PublishAsABlock(PublishAsABlockRequest) returns (PublishAsABlockResponse) {}
@@ -196,6 +203,19 @@ message FlushOperationsBufferRequest {
  */
 message FlushOperationsBufferResponse {
     int32 sent_operations_amount = 1; // Amount of operations retrieved from the buffer, and submitted to the ledger.
+}
+
+/**
+ * Request to retrieve the timestamp of the latest synchronized (processed by PRISM Node) block.
+ */
+message GetLastSyncedBlockTimestampRequest {
+}
+
+/**
+ * Response with the timestamp of the latest synchronized (processed by PRISM Node) block.
+ */
+message GetLastSyncedBlockTimestampResponse {
+    google.protobuf.Timestamp last_synced_block_timestamp = 1; // Timestamp of the latest synchronized (processed by PRISM Node) block.
 }
 
 message PublishAsABlockRequest {


### PR DESCRIPTION
## Overview
<!-- What this PR does, and why is needed, a useful description is expected, and relevant tickets should be mentioned -->
This PR introduces a new RPC call for retrieving the timestamp of the latest synced block.

## Screenshots
<!-- In case the PR involves UI changes, make sure to include success/failure related screenshots -->

## Checklists
<!-- Details you need to consider that are commonly forgotten -->

Pre-submit checklist:
- [x] Self-reviewed the diff
- [x] New code has proper comments/documentation/tests
- [x] Any changes not covered by tests have been tested manually
- [ ] The README files are updated
- [ ] If new libraries are included, they have licenses compatible with our project
- [ ] If there is a db migration altering existing tables, there is a proper migration test

Pre-merge checklist:
- [x] Commits have useful messages
- [ ] Review clarifications made it into the code
