### PR TITLE
ATA-5410: Add object size check to publishAsABlock rpc call

### DIFF
--- a/prism-backend/node/src/main/scala/io/iohk/atala/prism/node/NodeServiceImpl.scala
+++ b/prism-backend/node/src/main/scala/io/iohk/atala/prism/node/NodeServiceImpl.scala
@@ -34,8 +34,8 @@ import org.slf4j.{Logger, LoggerFactory}
 import java.time.Instant
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
-
 import io.iohk.atala.prism.interop.toScalaProtos._
+import io.iohk.atala.prism.node.cardano.models.AtalaObjectMetadata
 
 class NodeServiceImpl(
     didDataRepository: DIDDataRepository[IO],
@@ -258,6 +258,12 @@ class NodeServiceImpl(
       .fromTry {
         Try {
           require(request.signedOperations.nonEmpty, "there must be at least one operation to be published")
+
+          val obj = ObjectManagementService.createAtalaObject(request.signedOperations.toList)
+          require(
+            AtalaObjectMetadata.estimateTxMetadataSize(obj) <= cardano.TX_METADATA_MAX_SIZE,
+            "atala object size is too big"
+          )
           request.signedOperations
         }
       }

--- a/prism-backend/node/src/main/scala/io/iohk/atala/prism/node/models/package.scala
+++ b/prism-backend/node/src/main/scala/io/iohk/atala/prism/node/models/package.scala
@@ -29,6 +29,8 @@ package object models {
 
   }
 
+  val ATALA_OBJECT_VERSION: String = "1.0"
+
   case class DIDPublicKey(didSuffix: DIDSuffix, keyId: String, keyUsage: KeyUsage, key: ECPublicKey)
 
   case class DIDData(didSuffix: DIDSuffix, keys: List[DIDPublicKey], lastOperation: SHA256Digest)


### PR DESCRIPTION
## Overview
<!-- What this PR does, and why is needed, a useful description is expected, and relevant tickets should be mentioned -->
Checks that the size of operations we're trying to publish is not too big.
It also slightly improves logging 
## Screenshots
<!-- In case the PR involves UI changes, make sure to include success/failure related screenshots -->

## Checklists
<!-- Details you need to consider that are commonly forgotten -->

Pre-submit checklist:
- [x] Self-reviewed the diff
- [x] New code has proper comments/documentation/tests
- [x] Any changes not covered by tests have been tested manually
- [ ] The README files are updated
- [ ] If new libraries are included, they have licenses compatible with our project
- [ ] If there is a db migration altering existing tables, there is a proper migration test

Pre-merge checklist:
- [x] Commits have useful messages
- [ ] Review clarifications made it into the code
