### PR TITLE
ATA-5426: change processed to AtalaObjectStatus

### DIFF
--- a/prism-backend/node/src/main/resources/db/migration/V23__add_atala_object_status.sql
+++ b/prism-backend/node/src/main/resources/db/migration/V23__add_atala_object_status.sql
@@ -1,0 +1,10 @@
+CREATE TYPE ATALA_OBJECT_STATUS AS ENUM('PENDING', 'MERGED', 'PROCESSED');
+
+ALTER TABLE atala_objects
+  ADD COLUMN atala_object_status ATALA_OBJECT_STATUS DEFAULT 'PENDING';
+
+UPDATE atala_objects
+  SET atala_object_status = 'PROCESSED'
+  WHERE processed = true;
+
+ALTER TABLE atala_objects DROP COLUMN processed;

--- a/prism-backend/node/src/main/scala/io/iohk/atala/prism/node/models/package.scala
+++ b/prism-backend/node/src/main/scala/io/iohk/atala/prism/node/models/package.scala
@@ -31,6 +31,15 @@ package object models {
 
   val ATALA_OBJECT_VERSION: String = "1.0"
 
+  sealed trait AtalaObjectStatus extends EnumEntry with UpperSnakecase
+  object AtalaObjectStatus extends Enum[AtalaObjectStatus] {
+    val values = findValues
+
+    case object Pending extends AtalaObjectStatus
+    case object Merged extends AtalaObjectStatus
+    case object Processed extends AtalaObjectStatus
+  }
+
   case class DIDPublicKey(didSuffix: DIDSuffix, keyId: String, keyUsage: KeyUsage, key: ECPublicKey)
 
   case class DIDData(didSuffix: DIDSuffix, keys: List[DIDPublicKey], lastOperation: SHA256Digest)

--- a/prism-backend/node/src/main/scala/io/iohk/atala/prism/node/repositories/AtalaOperationsRepository.scala
+++ b/prism-backend/node/src/main/scala/io/iohk/atala/prism/node/repositories/AtalaOperationsRepository.scala
@@ -7,7 +7,13 @@ import doobie.implicits._
 import doobie.util.transactor.Transactor
 import io.iohk.atala.prism.connector.AtalaOperationId
 import io.iohk.atala.prism.node.errors.NodeError
-import io.iohk.atala.prism.node.models.{AtalaObjectId, AtalaObjectInfo, AtalaOperationInfo, AtalaOperationStatus}
+import io.iohk.atala.prism.node.models.{
+  AtalaObjectId,
+  AtalaObjectInfo,
+  AtalaObjectStatus,
+  AtalaOperationInfo,
+  AtalaOperationStatus
+}
 import io.iohk.atala.prism.node.repositories.daos.{AtalaObjectsDAO, AtalaOperationsDAO}
 import io.iohk.atala.prism.node.repositories.daos.AtalaObjectsDAO.AtalaObjectCreateData
 import io.iohk.atala.prism.utils.syntax.DBConnectionOps
@@ -76,7 +82,7 @@ private final class AtalaOperationsRepositoryImpl[F[_]: BracketThrow](xa: Transa
         operations.map(AtalaOperationId.of),
         atalaObject.objectId
       )
-      _ <- AtalaObjectsDAO.setProcessedBatch(oldObjects.map(_.objectId))
+      _ <- AtalaObjectsDAO.updateObjectStatusBatch(oldObjects.map(_.objectId), AtalaObjectStatus.Merged)
     } yield ()
 
     val opDescription = s"record new Atala Object ${atalaObject.objectId}"

--- a/prism-backend/node/src/main/scala/io/iohk/atala/prism/node/repositories/daos/AtalaObjectsDAO.scala
+++ b/prism-backend/node/src/main/scala/io/iohk/atala/prism/node/repositories/daos/AtalaObjectsDAO.scala
@@ -8,7 +8,7 @@ import doobie.implicits._
 import doobie.implicits.legacy.instant._
 import doobie.util.fragments.in
 import io.iohk.atala.prism.models.TransactionInfo
-import io.iohk.atala.prism.node.models.{AtalaObjectId, AtalaObjectInfo}
+import io.iohk.atala.prism.node.models.{AtalaObjectId, AtalaObjectInfo, AtalaObjectStatus}
 
 import java.time.Instant
 
@@ -42,7 +42,7 @@ object AtalaObjectsDAO {
 
   def get(objectId: AtalaObjectId): ConnectionIO[Option[AtalaObjectInfo]] = {
     sql"""
-         |SELECT obj.atala_object_id, obj.object_content, obj.processed,
+         |SELECT obj.atala_object_id, obj.object_content, obj.atala_object_status,
          |       tx.transaction_id, tx.ledger, tx.block_number, tx.block_timestamp, tx.block_index
          |FROM atala_objects AS obj
          |  LEFT OUTER JOIN atala_object_txs AS tx ON tx.atala_object_id = obj.atala_object_id
@@ -56,7 +56,7 @@ object AtalaObjectsDAO {
     sql"""
        |SELECT obj.atala_object_id
        |FROM atala_objects AS obj
-       |WHERE processed = false and NOT EXISTS
+       |WHERE atala_object_status = 'PENDING' and NOT EXISTS
        |(
        |  SELECT 1
        |    FROM atala_object_tx_submissions
@@ -68,17 +68,18 @@ object AtalaObjectsDAO {
       .to[List]
   }
 
-  def setProcessed(objectId: AtalaObjectId, processed: Boolean = true): ConnectionIO[Unit] = {
+  def updateObjectStatus(objectId: AtalaObjectId, newStatus: AtalaObjectStatus): ConnectionIO[Unit] = {
     sql"""
          |UPDATE atala_objects
-         |SET processed = $processed
-         |WHERE atala_object_id = $objectId""".stripMargin.update.run.void
+         |SET atala_object_status = $newStatus
+         |WHERE atala_object_id = $objectId
+      """.stripMargin.update.run.void
   }
 
-  def setProcessedBatch(objectIds: List[AtalaObjectId], processed: Boolean = true): ConnectionIO[Unit] = {
+  def updateObjectStatusBatch(objectIds: List[AtalaObjectId], newStatus: AtalaObjectStatus): ConnectionIO[Unit] = {
     NonEmptyList.fromList(objectIds).fold(unit) { objectIdsNonEmpty =>
       val fragment = fr"UPDATE atala_objects" ++
-        fr"SET processed = $processed" ++
+        fr"SET atala_object_status = $newStatus" ++
         fr"WHERE" ++ in(fr"atala_object_id", objectIdsNonEmpty)
       fragment.update.run.void
     }

--- a/prism-backend/node/src/main/scala/io/iohk/atala/prism/node/repositories/daos/package.scala
+++ b/prism-backend/node/src/main/scala/io/iohk/atala/prism/node/repositories/daos/package.scala
@@ -37,6 +37,13 @@ package object daos extends BaseDAO {
       _.entryName
     )
 
+  implicit val pgAtalaObjectStatus: Meta[AtalaObjectStatus] =
+    pgEnumString[AtalaObjectStatus](
+      "ATALA_OBJECT_STATUS",
+      a => AtalaObjectStatus.withNameOption(a).getOrElse(throw InvalidEnum[AtalaObjectStatus](a)),
+      _.entryName
+    )
+
   implicit val pgOperationStatusMeta: Meta[AtalaOperationStatus] =
     pgEnumString[AtalaOperationStatus](
       "ATALA_OPERATION_STATUS",
@@ -173,7 +180,7 @@ package object daos extends BaseDAO {
       (
           AtalaObjectId,
           Array[Byte],
-          Boolean,
+          AtalaObjectStatus,
           Option[TransactionId],
           Option[Ledger],
           Option[Int],
@@ -184,7 +191,7 @@ package object daos extends BaseDAO {
       case (
             objectId,
             byteContent,
-            processed,
+            status,
             maybeTransactionId,
             maybeLedger,
             maybeBlockNumber,
@@ -194,7 +201,7 @@ package object daos extends BaseDAO {
         AtalaObjectInfo(
           objectId,
           byteContent,
-          processed,
+          status,
           (maybeTransactionId, maybeLedger, maybeBlockNumber, maybeBlockTimestamp, maybeBlockIndex) match {
             case (Some(transactionId), Some(ledger), Some(blockNumber), Some(blockTimestamp), Some(blockIndex)) =>
               Some(TransactionInfo(transactionId, ledger, Some(BlockInfo(blockNumber, blockTimestamp, blockIndex))))

--- a/prism-backend/node/src/main/scala/io/iohk/atala/prism/node/services/ObjectManagementService.scala
+++ b/prism-backend/node/src/main/scala/io/iohk/atala/prism/node/services/ObjectManagementService.scala
@@ -136,7 +136,7 @@ class ObjectManagementService private (
       )
     } yield for {
       wasProcessed <- blockProcessed
-      _ <- AtalaObjectsDAO.setProcessed(obj.objectId)
+      _ <- AtalaObjectsDAO.updateObjectStatus(obj.objectId, AtalaObjectStatus.Processed)
     } yield wasProcessed
   }
 

--- a/prism-backend/node/src/test/scala/io/iohk/atala/prism/node/models/AtalaObjectInfoSpec.scala
+++ b/prism-backend/node/src/test/scala/io/iohk/atala/prism/node/models/AtalaObjectInfoSpec.scala
@@ -17,7 +17,10 @@ class AtalaObjectInfoSpec extends AtalaWithPostgresSpec {
     )
   }
 
-  private def createAtalaObject(ops: Seq[SignedAtalaOperation], processed: Boolean = false) = {
+  private def createAtalaObject(
+      ops: Seq[SignedAtalaOperation],
+      status: AtalaObjectStatus = AtalaObjectStatus.Pending
+  ) = {
     val blockContent = node_internal
       .AtalaObject(
         blockOperationCount = ops.size
@@ -26,7 +29,7 @@ class AtalaObjectInfoSpec extends AtalaWithPostgresSpec {
     AtalaObjectInfo(
       objectId = AtalaObjectId.of(blockContent),
       blockContent.toByteArray,
-      processed = processed
+      status = status
     )
   }
 
@@ -56,7 +59,7 @@ class AtalaObjectInfoSpec extends AtalaWithPostgresSpec {
     }
 
     "not merge objects if one of them was processed" in {
-      val processedAtalaObject = createAtalaObject(dummySignedOperations.take(2), processed = true)
+      val processedAtalaObject = createAtalaObject(dummySignedOperations.take(2), status = AtalaObjectStatus.Processed)
       val atalaObject = createAtalaObject(dummySignedOperations.drop(2))
       val maybeMerged1 = processedAtalaObject.mergeIfPossible(atalaObject)
       val maybeMerged2 = atalaObject.mergeIfPossible(processedAtalaObject)
@@ -70,7 +73,7 @@ class AtalaObjectInfoSpec extends AtalaWithPostgresSpec {
       val invalidAtalaObject = AtalaObjectInfo(
         objectId = AtalaObjectId.of(invalidBlockContent),
         invalidBlockContent,
-        processed = false
+        status = AtalaObjectStatus.Pending
       )
       val atalaObject = createAtalaObject(dummySignedOperations)
       val maybeMerged1 = atalaObject.mergeIfPossible(invalidAtalaObject)

--- a/prism-backend/node/src/test/scala/io/iohk/atala/prism/node/repositories/daos/AtalaObjectsDAOSpec.scala
+++ b/prism-backend/node/src/test/scala/io/iohk/atala/prism/node/repositories/daos/AtalaObjectsDAOSpec.scala
@@ -5,7 +5,7 @@ import doobie.implicits._
 import io.iohk.atala.prism.AtalaWithPostgresSpec
 import io.iohk.atala.prism.kotlin.crypto.SHA256Digest
 import io.iohk.atala.prism.models.{BlockInfo, Ledger, TransactionId, TransactionInfo}
-import io.iohk.atala.prism.node.models.{AtalaObjectInfo, AtalaObjectId}
+import io.iohk.atala.prism.node.models.{AtalaObjectId, AtalaObjectInfo, AtalaObjectStatus}
 import io.iohk.atala.prism.protos.node_internal
 import org.scalatest.OptionValues._
 
@@ -28,7 +28,7 @@ class AtalaObjectsDAOSpec extends AtalaWithPostgresSpec {
       retrieved.objectId mustBe objectId
       retrieved.byteContent mustBe byteContent
       retrieved.transaction mustBe None
-      retrieved.processed mustBe false
+      retrieved.status mustBe AtalaObjectStatus.Pending
     }
   }
 
@@ -45,7 +45,7 @@ class AtalaObjectsDAOSpec extends AtalaWithPostgresSpec {
       retrieved.objectId mustBe objectId
       retrieved.byteContent mustBe byteContent
       retrieved.transaction.value mustBe transactionInfo
-      retrieved.processed mustBe false
+      retrieved.status mustBe AtalaObjectStatus.Pending
     }
 
     "fail to set the transaction info of a nonexistent object" in {
@@ -80,7 +80,7 @@ class AtalaObjectsDAOSpec extends AtalaWithPostgresSpec {
       retrieved.objectId mustBe objectId
       retrieved.byteContent mustBe byteContent
       retrieved.transaction mustBe None
-      retrieved.processed mustBe false
+      retrieved.status mustBe AtalaObjectStatus.Pending
     }
 
     "get an object with transaction info" in {
@@ -95,7 +95,7 @@ class AtalaObjectsDAOSpec extends AtalaWithPostgresSpec {
       retrieved.objectId mustBe objectId
       retrieved.byteContent mustBe byteContent
       retrieved.transaction.value mustBe transactionInfo
-      retrieved.processed mustBe false
+      retrieved.status mustBe AtalaObjectStatus.Pending
     }
   }
 
@@ -103,10 +103,10 @@ class AtalaObjectsDAOSpec extends AtalaWithPostgresSpec {
     "mark object as processed" in {
       insert(objectId, byteContent)
 
-      AtalaObjectsDAO.setProcessed(objectId).transact(database).unsafeRunSync()
+      AtalaObjectsDAO.updateObjectStatus(objectId, AtalaObjectStatus.Processed).transact(database).unsafeRunSync()
 
       val retrieved = get(objectId)
-      retrieved.processed mustBe true
+      retrieved.status mustBe AtalaObjectStatus.Processed
     }
   }
 

--- a/prism-backend/node/src/test/scala/io/iohk/atala/prism/node/services/ObjectManagementServiceSpec.scala
+++ b/prism-backend/node/src/test/scala/io/iohk/atala/prism/node/services/ObjectManagementServiceSpec.scala
@@ -10,6 +10,7 @@ import io.iohk.atala.prism.models.{BlockInfo, Ledger, TransactionId, Transaction
 import io.iohk.atala.prism.node.models.{
   AtalaObjectId,
   AtalaObjectInfo,
+  AtalaObjectStatus,
   AtalaObjectTransactionSubmission,
   AtalaObjectTransactionSubmissionStatus,
   AtalaOperationStatus
@@ -263,7 +264,7 @@ class ObjectManagementServiceSpec
       verifyNoMoreInteractions(blockProcessing)
 
       val atalaObject = queryAtalaObject(obj)
-      atalaObject.processed mustBe true
+      atalaObject.status mustBe AtalaObjectStatus.Processed
     }
 
     def queryAtalaObject(obj: node_internal.AtalaObject): AtalaObjectInfo = {


### PR DESCRIPTION
## Overview
<!-- What this PR does, and why is needed, a useful description is expected, and relevant tickets should be mentioned -->
PR changes `processed` field to less confusing `atala_object_status`.

## Screenshots
<!-- In case the PR involves UI changes, make sure to include success/failure related screenshots -->

## Checklists
<!-- Details you need to consider that are commonly forgotten -->

Pre-submit checklist:
- [x] Self-reviewed the diff
- [x] New code has proper comments/documentation/tests
- [x] Any changes not covered by tests have been tested manually
- [ ] The README files are updated
- [ ] If new libraries are included, they have licenses compatible with our project
- [ ] If there is a db migration altering existing tables, there is a proper migration test

Pre-merge checklist:
- [x] Commits have useful messages
- [ ] Review clarifications made it into the code
