### PR TITLE
ATA-5441: Store parsed operations in AtalaObjectInfo

### DIFF
--- a/prism-backend/node/src/test/scala/io/iohk/atala/prism/node/models/AtalaObjectInfoSpec.scala
+++ b/prism-backend/node/src/test/scala/io/iohk/atala/prism/node/models/AtalaObjectInfoSpec.scala
@@ -6,6 +6,8 @@ import io.iohk.atala.prism.node.services.BlockProcessingServiceSpec
 import io.iohk.atala.prism.protos.node_models.SignedAtalaOperation
 import io.iohk.atala.prism.protos.node_internal
 
+import org.scalatest.OptionValues._
+
 class AtalaObjectInfoSpec extends AtalaWithPostgresSpec {
 
   private val dummyAtalaOperation = BlockProcessingServiceSpec.createDidOperation
@@ -37,7 +39,7 @@ class AtalaObjectInfoSpec extends AtalaWithPostgresSpec {
     "merge two valid objects" in {
       val atalaObject1 = createAtalaObject(dummySignedOperations.take(2))
       val atalaObject2 = createAtalaObject(dummySignedOperations.drop(2))
-      val atalaObjectMerged = atalaObject1.mergeIfPossible(atalaObject2).get
+      val atalaObjectMerged = atalaObject1.mergeIfPossible(atalaObject2).value
       val expectedAtalaObject = createAtalaObject(dummySignedOperations)
 
       atalaObjectMerged must be(expectedAtalaObject)


### PR DESCRIPTION
## Overview
<!-- What this PR does, and why is needed, a useful description is expected, and relevant tickets should be mentioned -->
This PR stores parsed operations as a part of AtalaObjectInfo. This should help us with further dependency analysis.

## Screenshots
<!-- In case the PR involves UI changes, make sure to include success/failure related screenshots -->

## Checklists
<!-- Details you need to consider that are commonly forgotten -->

Pre-submit checklist:
- [x] Self-reviewed the diff
- [x] New code has proper comments/documentation/tests
- [x] Any changes not covered by tests have been tested manually
- [ ] The README files are updated
- [ ] If new libraries are included, they have licenses compatible with our project
- [ ] If there is a db migration altering existing tables, there is a proper migration test

Pre-merge checklist:
- [x] Commits have useful messages
- [ ] Review clarifications made it into the code
