### PR TITLE
ATA-5478: Temporal fix for credential revocation

### DIFF
--- a/prism-backend/node/src/main/scala/io/iohk/atala/prism/node/models/package.scala
+++ b/prism-backend/node/src/main/scala/io/iohk/atala/prism/node/models/package.scala
@@ -15,7 +15,9 @@ import scala.util.matching.Regex
 package object models {
   sealed trait KeyUsage extends EnumEntry with UpperSnakecase {
     def canIssue: Boolean = this == KeyUsage.IssuingKey
-    def canRevoke: Boolean = this == KeyUsage.RevocationKey
+    // TODO: Once the wallet is able to use the revocation key, make sure that credentials
+    // can be revoked only with the revocation key.
+    def canRevoke: Boolean = this == KeyUsage.RevocationKey || this == KeyUsage.IssuingKey
   }
 
   object KeyUsage extends Enum[KeyUsage] {


### PR DESCRIPTION
## Overview
<!-- What this PR does, and why is needed, a useful description is expected, and relevant tickets should be mentioned -->
The wallet is unable to revoke credentials because the node requires
a revocation key, unfortunately, there is no simple way to add such
key to the wallet until the SDK is upgraded, which is blocked by a
bug in kotlinjs.

As a temporal workaround, let's allow revoking credentials with the issuance key.

## Screenshots
<!-- In case the PR involves UI changes, make sure to include success/failure related screenshots -->

## Checklists
<!-- Details you need to consider that are commonly forgotten -->

Pre-submit checklist:
- [ ] Self-reviewed the diff
- [ ] New code has proper comments/documentation/tests
- [ ] Any changes not covered by tests have been tested manually
- [ ] The README files are updated
- [ ] If new libraries are included, they have licenses compatible with our project
- [ ] If there is a db migration altering existing tables, there is a proper migration test

Pre-merge checklist:
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
