### PR TITLE
No-Jira: monitoring: graph instead of gauge for available wallet funds metric

### DIFF
--- a/prism-backend/infra/monitoring/grafana/node-dashboard.json
+++ b/prism-backend/infra/monitoring/grafana/node-dashboard.json
@@ -16,7 +16,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": 12,
-  "iteration": 1632291728603,
+  "iteration": 1633509124073,
   "links": [],
   "panels": [
     {
@@ -1388,55 +1388,53 @@
       }
     },
     {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
       "datasource": null,
       "description": "Wallet available funds",
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
           "unit": "lovelace"
         },
         "overrides": []
       },
+      "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 9,
         "w": 12,
         "x": 0,
         "y": 62
       },
+      "hiddenSeries": false,
       "id": 27,
       "interval": null,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "text": {},
-        "textMode": "auto"
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
       },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
       "pluginVersion": "7.5.4",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
       "targets": [
         {
           "exemplar": true,
@@ -1447,10 +1445,46 @@
           "refId": "A"
         }
       ],
+      "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Wallet available funds",
-      "type": "stat"
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "lovelace",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -1994,6 +2028,7 @@
         "allValue": null,
         "current": {
           "selected": true,
+          "tags": [],
           "text": [
             "All"
           ],
@@ -2140,5 +2175,5 @@
   "timezone": "",
   "title": "Node",
   "uid": "5CpJH5W7k",
-  "version": 12
+  "version": 14
 }


### PR DESCRIPTION
## Overview
This PR changes the available wallet funds metric (in the grafana node dashboard) pane to graph (instead of gauge)

## Screenshots
<!-- In case the PR involves UI changes, make sure to include success/failure related screenshots -->

## Checklists
<!-- Details you need to consider that are commonly forgotten -->

Pre-submit checklist:
- [x] Self-reviewed the diff
- [ ] New code has proper comments/documentation/tests
- [ ] Any changes not covered by tests have been tested manually
- [ ] The README files are updated
- [ ] If new libraries are included, they have licenses compatible with our project
- [ ] If there is a db migration altering existing tables, there is a proper migration test

Pre-merge checklist:
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
