### PR TITLE
ATA-5562: Add missing foreign key to the received_credentials table

### DIFF
--- a/prism-backend/management-console/src/main/resources/db/migration/V16__received_credentials_contact_id_fk.sql
+++ b/prism-backend/management-console/src/main/resources/db/migration/V16__received_credentials_contact_id_fk.sql
@@ -1,0 +1,9 @@
+-- there was a bug which used an invalid contact_id while storing data in the received_credentials table
+-- which could have been prevented by having a fk
+
+-- first, all received_credentials need to be deleted because we can't fix the contact_id references
+DELETE FROM received_credentials;
+
+-- then, we add the fk
+ALTER TABLE received_credentials
+  ADD CONSTRAINT received_credentials_contact_id_fk FOREIGN KEY(contact_id) REFERENCES contacts(contact_id);


### PR DESCRIPTION
## Overview
<!-- What this PR does, and why is needed, a useful description is expected, and relevant tickets should be mentioned -->
Now, the contact_id has a foreign key to make sure that a received
credential is always linked to a contact.

While the tests succeed, the integration with the wallet is now broken
because the wallet is submitting a connection_id instead of a contact_id,
it is better to be aware of the issue instead of thinking that everything
is working.

## Screenshots
<!-- In case the PR involves UI changes, make sure to include success/failure related screenshots -->

## Checklists
<!-- Details you need to consider that are commonly forgotten -->

Pre-submit checklist:
- [x] Self-reviewed the diff
- [x] New code has proper comments/documentation/tests
- [x] Any changes not covered by tests have been tested manually
- [x] The README files are updated
- [ ] If new libraries are included, they have licenses compatible with our project
- [ ] If there is a db migration altering existing tables, there is a proper migration test

Pre-merge checklist:
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
