### PR TITLE
fix: prevent failing compilation by eslint errors on dev enviroment 

### DIFF
--- a/prism-management-console-web/package.json
+++ b/prism-management-console-web/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "prestart": "./scripts/compile-protos.sh",
-    "start": "./scripts/copyEnvVarsToWindow.sh && cp env-config.js ./public/ && DISABLE_ESLINT_PLUGIN=true react-scripts start",
+    "start": "./scripts/copyEnvVarsToWindow.sh && cp env-config.js ./public/ && ESLINT_NO_DEV_ERRORS=true react-scripts start",
     "prestart-test-server": "./scripts/compile-protos.sh",
     "start-test-server": "cp ./cypress/App.js ./src/ && react-scripts start",
     "prebuild": "./scripts/compile-protos.sh",


### PR DESCRIPTION
## Overview
<!-- What this PR does, and why is needed, a useful description is expected, and relevant tickets should be mentioned -->
This might look a bit controversial. The `react-scripts 4.0.3` upgrade introduced an issue where an eslint error causes compilation to fail, even on dev environment. That means one can't even add a `debugger` statement 

The proposed solution only affects the dev environment, production shouldn't be affected. 

Note: Here's a related [discussion](https://github.com/facebook/create-react-app/issues/9887) on the `create-react-app` repo 

## Screenshots
<!-- In case the PR involves UI changes, make sure to include success/failure related screenshots -->

## Checklists
<!-- Details you need to consider that are commonly forgotten -->

Pre-submit checklist:
- [x] Self-reviewed the diff
- [x] New code has proper comments/documentation/tests
- [x] Any changes not covered by tests have been tested manually
- [x] The README files are updated
- [x] If new libraries are included, they have licenses compatible with our project
- [x] If there is a db migration altering existing tables, there is a proper migration test

Pre-merge checklist:
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
