### PR TITLE
fix: prevent filters to render on the wrong steps of credential creation

### DIFF
--- a/prism-management-console-web/src/components/newCredential/NewCredential.jsx
+++ b/prism-management-console-web/src/components/newCredential/NewCredential.jsx
@@ -8,7 +8,8 @@ import GenericStepsButtons from '../common/Molecules/GenericStepsButtons/Generic
 import {
   NEW_CREDENTIALS_STEP_UNIT,
   SELECT_RECIPIENTS_STEP,
-  IMPORT_CREDENTIAL_DATA_STEP
+  IMPORT_CREDENTIAL_DATA_STEP,
+  SELECT_CREDENTIAL_TYPE_STEP
 } from '../../helpers/constants';
 import TemplateFiltersContainer from '../credentialTemplates/Molecules/Filters/TemplateFiltersContainer';
 
@@ -54,9 +55,11 @@ const NewCredential = ({
         title={t(`newCredential.title.step${currentStep + 1}`)}
         subtitle={t(`newCredential.subtitle.step${currentStep + 1}`)}
       />
-      <div className="ActionsHeader EmbeddedTempalteFilters flex">
-        <TemplateFiltersContainer />
-      </div>
+      {currentStep === SELECT_CREDENTIAL_TYPE_STEP && (
+        <div className="ActionsHeader EmbeddedTempalteFilters flex">
+          <TemplateFiltersContainer />
+        </div>
+      )}
     </div>
   );
 


### PR DESCRIPTION
## Overview
<!-- What this PR does, and why is needed, a useful description is expected, and relevant tickets should be mentioned -->

Fixes issue where the template filters were rendered on the wrong step

## Screenshots
<!-- In case the PR involves UI changes, make sure to include success/failure related screenshots -->

## Checklists
<!-- Details you need to consider that are commonly forgotten -->

Pre-submit checklist:
- [x] Self-reviewed the diff
- [x] New code has proper comments/documentation/tests
- [x] Any changes not covered by tests have been tested manually
- [x] The README files are updated
- [x] If new libraries are included, they have licenses compatible with our project
- [x] If there is a db migration altering existing tables, there is a proper migration test

Pre-merge checklist:
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
