### PR TITLE
changed the logback stratergy

### DIFF
--- a/prism-backend/project/PrismBuild.scala
+++ b/prism-backend/project/PrismBuild.scala
@@ -47,10 +47,9 @@ object PrismBuild {
         Test / parallelExecution := false,
         Test / testForkedParallel := false,
         assembly / test := {},
-        commands += Command.args("testOnlyUntilFailed", "<testOnly params>") {
-          (state, args) =>
-            val argsString = args.mkString(" ")
-            ("testOnly " + argsString) :: ("testOnlyUntilFailed " + argsString) :: state
+        commands += Command.args("testOnlyUntilFailed", "<testOnly params>") { (state, args) =>
+          val argsString = args.mkString(" ")
+          ("testOnly " + argsString) :: ("testOnlyUntilFailed " + argsString) :: state
         },
         assembly / assemblyExcludedJars := {
           val cp = (assembly / fullClasspath).value
@@ -74,7 +73,7 @@ object PrismBuild {
             MergeStrategy.concat
           // It is safe to discard when building an uber-jar according to https://stackoverflow.com/a/55557287
           case x if x.endsWith("module-info.class") => MergeStrategy.discard
-          case "logback.xml"                        => MergeStrategy.concat
+          case "logback.xml" => MergeStrategy.first
           case "scala-collection-compat.properties" => MergeStrategy.last
           // org.bitcoin classes are coming from both bitcoinj and fr.acinq.secp256k1-jni
           case PathList("org", "bitcoin", _*) => MergeStrategy.last
@@ -92,8 +91,7 @@ object PrismBuild {
         // Make ScalaPB compile protos relative to `protobuf_external_src/protos` directory.
         // Otherwise, it will assume that `protobuf_external_src` is the root directory for proto files.
         Compile / PB.protoSources := (Compile / PB.protoSources).value.map {
-          case externalSrc
-              if externalSrc.toPath.endsWith("protobuf_external_src") =>
+          case externalSrc if externalSrc.toPath.endsWith("protobuf_external_src") =>
             externalSrc / "proto"
           case other => other
         },


### PR DESCRIPTION
## Overview
After kamon upgrade 2.3.1 , The kamon upgrade brings a logback.xml as part of Kamon-bundle, IMO that is a mistake the way Kamon-bundle is building as the library shouldn't include logback.xml in the published jar.  when we packaged the application jar with the current strategy we have for logback  is to `contatenate` which is wrong as well causing the issue of parsing the logback XML (as there 2 logback files concatenated together). 
## Screenshots
<!-- In case the PR involves UI changes, make sure to include success/failure related screenshots -->

## Checklists
<!-- Details you need to consider that are commonly forgotten -->

Pre-submit checklist:
- [x] Self-reviewed the diff
- [x] New code has proper comments/documentation/tests
- [x] Any changes not covered by tests have been tested manually
- [x] The README files are updated
- [ ] If new libraries are included, they have licenses compatible with our project
- [ ] If there is a db migration altering existing tables, there is a proper migration test

Pre-merge checklist:
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
