### PR TITLE
ATA-5788: Remove FlushOperationsBuffer from SubmissionSchedulingService

### DIFF
--- a/prism-backend/node/src/main/scala/io/iohk/atala/prism/node/HealthService.scala
+++ b/prism-backend/node/src/main/scala/io/iohk/atala/prism/node/HealthService.scala
@@ -2,20 +2,27 @@ package io.iohk.atala.prism.node
 
 import _root_.grpc.health.v1.health._
 import io.grpc.stub.StreamObserver
+import org.slf4j.LoggerFactory
 
 import scala.concurrent.Future
 
 /** Simple Health service, for now, the service is healthy if the request is received.
   */
 class HealthService extends HealthGrpc.Health {
-  def check(request: HealthCheckRequest): Future[HealthCheckResponse] =
+  private val logger = LoggerFactory.getLogger(this.getClass)
+
+  def check(request: HealthCheckRequest): Future[HealthCheckResponse] = {
+    logger.info(s"Replying to health request, service = ${request.service}")
     Future.successful(servingResponse)
+  }
 
   def watch(
       request: HealthCheckRequest,
       responseObserver: StreamObserver[HealthCheckResponse]
-  ): Unit =
+  ): Unit = {
+    logger.info(s"Watch for health changes, service = ${request.service}")
     responseObserver.onNext(servingResponse)
+  }
 
   private val servingResponse =
     HealthCheckResponse().withStatus(HealthCheckResponse.ServingStatus.SERVING)


### PR DESCRIPTION
## Overview
<!-- What this PR does, and why is needed, a useful description is expected, and relevant tickets should be mentioned -->
- Removes `flushOperationsBuffer` logic from `SubmissionSchedulingService`.
- Adds short description for `SubmissionSchedulingService`

## Screenshots
<!-- In case the PR involves UI changes, make sure to include success/failure related screenshots -->

## Checklists
<!-- Details you need to consider that are commonly forgotten -->

Pre-submit checklist:
- [x] Self-reviewed the diff
- [x] New code has proper comments/documentation/tests
- [x] Any changes not covered by tests have been tested manually
- [ ] The README files are updated
- [ ] If new libraries are included, they have licenses compatible with our project
- [ ] If there is a db migration altering existing tables, there is a proper migration test

Pre-merge checklist:
- [x] Commits have useful messages
- [ ] Review clarifications made it into the code
