### PR TITLE
ATA-5833 Updated the CITEXT to TEXT

### DIFF
--- a/prism-backend/management-console/src/main/resources/db/migration/V4__create_credential_types.sql
+++ b/prism-backend/management-console/src/main/resources/db/migration/V4__create_credential_types.sql
@@ -1,11 +1,9 @@
 
-CREATE EXTENSION IF NOT EXISTS citext;
-
 CREATE TYPE CREDENTIAL_TYPE_STATE AS ENUM ('DRAFT', 'READY', 'ARCHIVED');
 
 CREATE TABLE credential_types(
     credential_type_id UUID NOT NULL,
-    name CITEXT NOT NULL,
+    name TEXT NOT NULL,
     institution_id UUID NOT NULL,
     state CREDENTIAL_TYPE_STATE NOT NULL,
     template TEXT NOT NULL,


### PR DESCRIPTION
## Overview
This change is required as the CITEXT module is not loaded in the AWS environment as it is related to the privilege issue
causing the unpublished DID not create in the management console database, Hence the management console is not usable
When this PR is merged it requires **Manually** dropping of the management console schema in the AWS environment(same will be required if locally you have PostgresSQL running), This will allow the new schema to be created by the flyway
This also affects all the environments including PPP hence the step of dropping schema for management console is applicable in all the environments before this change is propagated.

https://www.postgresql.org/docs/14/sql-createextension.html
Please see below
https://input-output-rnd.slack.com/archives/C012T7UP886/p1637691973130100?thread_ts=1637588940.125500&cid=C012T7UP886

## Screenshots
<!-- In case the PR involves UI changes, make sure to include success/failure related screenshots -->

## Checklists
<!-- Details you need to consider that are commonly forgotten -->

Pre-submit checklist:
- [x] Self-reviewed the diff
- [x] New code has proper comments/documentation/tests
- [x] Any changes not covered by tests have been tested manually
- [ ] The README files are updated
- [ ] If new libraries are included, they have licenses compatible with our project
- [ ] If there is a db migration altering existing tables, there is a proper migration test

Pre-merge checklist:
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
