### PR TITLE
ATA-5334: Fix pattern matching in extractSingleOperationOutput

### DIFF
--- a/prism-backend/common/src/main/scala/io/iohk/atala/prism/utils/GrpcUtils.scala
+++ b/prism-backend/common/src/main/scala/io/iohk/atala/prism/utils/GrpcUtils.scala
@@ -17,7 +17,7 @@ object GrpcUtils {
 
   def extractSingleOperationOutput(scheduleOperationsResponse: ScheduleOperationsResponse): OperationOutput =
     scheduleOperationsResponse.outputs match {
-      case head :: Nil => head
+      case Seq(head) => head
       case outputs =>
         throw new RuntimeException(s"1 operation output expected but got ${outputs.size}")
     }

--- a/prism-backend/common/src/test/scala/io/iohk/atala/prism/utils/GrpcUtilsSpec.scala
+++ b/prism-backend/common/src/test/scala/io/iohk/atala/prism/utils/GrpcUtilsSpec.scala
@@ -1,0 +1,41 @@
+package io.iohk.atala.prism.utils
+
+import com.google.protobuf.ByteString
+import io.iohk.atala.prism.protos.node_api.ScheduleOperationsResponse
+import io.iohk.atala.prism.protos.node_models.{OperationOutput, RevokeCredentialsOutput}
+import org.scalatest.matchers.must.Matchers._
+import org.scalatest.wordspec.AnyWordSpec
+
+class GrpcUtilsSpec extends AnyWordSpec {
+  private val revokeCredentialsOperationOutput: OperationOutput = OperationOutput(
+    OperationOutput.Result.RevokeCredentialsOutput(RevokeCredentialsOutput()),
+    OperationOutput.OperationMaybe.OperationId(ByteString.copyFrom("aba".getBytes))
+  )
+
+  "extractSingleOperationOutput" should {
+    "correctly extract single output from Vector" in {
+      val operationOutput = GrpcUtils.extractSingleOperationOutput(
+        ScheduleOperationsResponse(Vector(revokeCredentialsOperationOutput))
+      )
+      operationOutput must be(revokeCredentialsOperationOutput)
+    }
+
+    "throw error on empty list" in {
+      val error = intercept[RuntimeException] {
+        GrpcUtils.extractSingleOperationOutput(
+          ScheduleOperationsResponse(Seq())
+        )
+      }
+      error.getMessage mustEqual "1 operation output expected but got 0"
+    }
+
+    "throw error when more than one output returned" in {
+      val error = intercept[RuntimeException] {
+        GrpcUtils.extractSingleOperationOutput(
+          ScheduleOperationsResponse(Seq(revokeCredentialsOperationOutput, revokeCredentialsOperationOutput))
+        )
+      }
+      error.getMessage mustEqual "1 operation output expected but got 2"
+    }
+  }
+}


### PR DESCRIPTION
## Overview
<!-- What this PR does, and why is needed, a useful description is expected, and relevant tickets should be mentioned -->
follow up PR for https://github.com/input-output-hk/atala-prism/pull/471/files
- it generalizes pattern matching for structures other than Lists
- it also adds unit tests for this method

## Screenshots
<!-- In case the PR involves UI changes, make sure to include success/failure related screenshots -->

## Checklists
<!-- Details you need to consider that are commonly forgotten -->

Pre-submit checklist:
- [x] Self-reviewed the diff
- [x] New code has proper comments/documentation/tests
- [x] Any changes not covered by tests have been tested manually
- [ ] The README files are updated
- [ ] If new libraries are included, they have licenses compatible with our project
- [ ] If there is a db migration altering existing tables, there is a proper migration test

Pre-merge checklist:
- [x] Commits have useful messages
- [ ] Review clarifications made it into the code
