### PR TITLE
ATA-6023: fix invalid date in templates page

### DIFF
--- a/prism-management-console-web/src/APIs/credentials/credentialTypesManager.js
+++ b/prism-management-console-web/src/APIs/credentials/credentialTypesManager.js
@@ -90,9 +90,13 @@ async function getCredentialTypes() {
   const categoriesAssociatedWithCredentialTypes = this.config.getCredentialTypesWithCategories();
   const credentialTypesWithCategories = credentialTypesList.map(c => ({
     ...c,
+    // The `lastEdited` attribute is not provided by the backend.
+    // However, it's value is equal to creation date since editing is not supported yet.
+    lastEdited: c.createdAt,
     icon: `${b64ImagePrefix},${c.icon}`,
     category: categoriesAssociatedWithCredentialTypes[c.id]
   }));
+
   Logger.info('got credential types: ', credentialTypesWithCategories);
 
   return credentialTypesWithCategories;

--- a/prism-management-console-web/src/helpers/tableDefinitions/templates.js
+++ b/prism-management-console-web/src/helpers/tableDefinitions/templates.js
@@ -39,7 +39,7 @@ export const getTemplatesColumns = (templateCategories, tableActions) => {
       key: 'lastEdited',
       width: 100,
       render: ({ lastEdited }) => (
-        <CellRenderer title={tp('lastEdited')} value={backendDateFormat(lastEdited)} light />
+        <CellRenderer title={tp('lastEdited')} value={backendDateFormat(lastEdited?.seconds)} />
       )
     }
   ];


### PR DESCRIPTION
## Overview
<!-- What this PR does, and why is needed, a useful description is expected, and relevant tickets should be mentioned -->

https://input-output.atlassian.net/browse/ATA-6023

Fixed issue with templates `lastEdited` attribute. A backend fix is needed 
(Reported here: https://input-output.atlassian.net/browse/ATA-6024)

## Screenshots
<!-- In case the PR involves UI changes, make sure to include success/failure related screenshots -->

### Before:
![image](https://user-images.githubusercontent.com/67912621/147500440-b4dd58d6-a8be-41f4-9b20-d38356617f55.png)

### After:
![image](https://user-images.githubusercontent.com/67912621/147500415-3cb857fe-0a21-4d58-908b-8756b77cf523.png)

## Checklists
<!-- Details you need to consider that are commonly forgotten -->

Pre-submit checklist:
- [x] Self-reviewed the diff
- [x] New code has proper comments/documentation/tests
- [x] Any changes not covered by tests have been tested manually
- [x] The README files are updated
- [x] If new libraries are included, they have licenses compatible with our project
- [x] If there is a db migration altering existing tables, there is a proper migration test

Pre-merge checklist:
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
