### PR TITLE
Hikari Connection Pool increase to 100 until we fix the underlying issue

### DIFF
--- a/prism-backend/common/src/main/scala/io/iohk/atala/prism/repositories/TransactorFactory.scala
+++ b/prism-backend/common/src/main/scala/io/iohk/atala/prism/repositories/TransactorFactory.scala
@@ -53,7 +53,7 @@ object TransactorFactory {
     for {
       // Resource yielding a transactor configured with a bounded connect EC and an unbounded
       // transaction EC. Everything will be closed and shut down cleanly after use.
-      ce <- ExecutionContexts.fixedThreadPool[A](config.awaitConnectionThreads) // our connect EC
+      ce <- ExecutionContexts.cachedThreadPool[A] // our connect EC
       xa <- HikariTransactor.fromHikariConfig[A](hikariConfig, ce)
     } yield xa
   }


### PR DESCRIPTION
Signed-off-by: Shailesh <shailesh.patil@iohk.io>

## Overview
This is a temporary increase in the connection pool and Currently, usage of the UI and Management console and KYC is high When using the getMessageStream the Stream doesn't release the connection. hence the connection is leaking.
Once the underline issue is fixed we need to reduce this

## Screenshots
<!-- In case the PR involves UI changes, make sure to include success/failure related screenshots -->

## Checklists
<!-- Details you need to consider that are commonly forgotten -->

Pre-submit checklist:
- [x] Self-reviewed the diff
- [x] New code has proper comments/documentation/tests
- [x] Any changes not covered by tests have been tested manually
- [ ] The README files are updated
- [ ] If new libraries are included, they have licenses compatible with our project
- [ ] If there is a db migration altering existing tables, there is a proper migration test

Pre-merge checklist:
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
