### PR TITLE
ATA-6236: Action to build and upload docs as GitHub page

### DIFF
--- a/.github/workflows/gh-pages-documentation-website.yml
+++ b/.github/workflows/gh-pages-documentation-website.yml
@@ -1,0 +1,52 @@
+name: Generate_Documentation
+
+on:
+  schedule:
+    - cron: 0 0 * * 6 #At 00:00 on Saturday
+  push:
+    branches:
+      - "master"
+    paths:
+      - "prism-backend/docs/**"
+  workflow_dispatch:
+
+jobs:
+  generate-and-deploy:
+    name: Generate_Documentation
+    concurrency:
+      group: make-docs-website
+      cancel-in-progress: true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: sudo apt-get install -y texlive-xetex pandoc pandoc-citeproc
+
+      - name: Make Site
+        run: |
+          mkdir website_folder
+          echo "theme: jekyll-theme-cayman" > website_folder/_config.yml
+          cat <<EOF > website_folder/README.md
+            # Documentation website
+
+            [Article](./article.pdf) about ...
+            
+            You can find the [Protocol here](./protocol.pdf).
+
+          EOF
+
+      - name: Generate Protocol's PDF
+        run: |
+          ./prism-backend/docs/protocol/make.sh 
+          cp ./prism-backend/docs/protocol/protocol.docx website_folder
+          cp ./prism-backend/docs/protocol/protocol.pdf website_folder
+
+      - name: Generate Article's PDF
+        run: |
+          make -C ./prism-backend/docs/article/
+          cp ./prism-backend/docs/article/article.pdf website_folder
+
+      - name: Deploy
+        uses: JamesIves/github-pages-deploy-action@v4.2.3
+        with:
+          branch: gh-pages # The branch the action should deploy to.
+          folder: website_folder # The folder the action should deploy.


### PR DESCRIPTION
## Overview
<!-- What this PR does, and why is needed, a useful description is expected, and relevant tickets should be mentioned -->

This was a suggestion for ATA-6236 to where we can store generated PDFs to be easily readable (and update).

This Github action will create a static site and push it to the `gh-pages` branch [GitHub Pages](https://pages.github.com/).
In this example the action will make the PDF for `prism-backend/docs/protocol/` (markdown format) and `prism-backend/docs/article/` (latex format).
We need to add a step for each PDF we want to create to the job, but on the other hand, we will have a lot of flexibility and can use any tool/format 

The PDFs will then be available on https://input-output-hk.github.io/atala-prism for anyone with access to this repository.

This branch will have a separate history from the rest of the repository, and will never be merged back into the other branches.
So if for some reason, the branch history gets too big, we can just delete it.

## Screenshots
<!-- In case the PR involves UI changes, make sure to include success/failure related screenshots -->
https://fabiopinheiro.github.io/docs-test/

## Checklists
<!-- Details you need to consider that are commonly forgotten -->

Pre-submit checklist:
- [x] Self-reviewed the diff
- [ ] New code has proper comments/documentation/tests
- [x] Any changes not covered by tests have been tested manually
- [ ] The README files are updated
- [ ] If new libraries are included, they have licenses compatible with our project
- [ ] If there is a db migration altering existing tables, there is a proper migration test

Pre-merge checklist:
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
