### PR TITLE
ATA-NoJira Code cleanup removed the override dependency scheme version

### DIFF
--- a/prism-backend/project/Dependencies.scala
+++ b/prism-backend/project/Dependencies.scala
@@ -157,7 +157,6 @@ object Dependencies {
     "com.thesamet.scalapb" %% "scalapb-runtime" % scalapb.compiler.Version.scalapbVersion % "protobuf",
     "com.thesamet.scalapb" %% "scalapb-runtime-grpc" % scalapb.compiler.Version.scalapbVersion
   )
-  val overrideVersionSchemes = libraryDependencySchemes += "org.tpolecat" %% "doobie-core" % VersionScheme.Always
 
   // cardano-address library binary
   val cardanoAddressBinaryUrl =

--- a/prism-backend/project/PrismBuild.scala
+++ b/prism-backend/project/PrismBuild.scala
@@ -119,7 +119,6 @@ object PrismBuild {
             ) ++
             prismDependencies ++
             scalapbDependencies,
-        overrideVersionSchemes,
         Compile / PB.targets := Seq(
           scalapb.gen() -> (Compile / sourceManaged).value / "proto"
         )
@@ -178,7 +177,6 @@ object PrismBuild {
     commonServerProject("node")
       .settings(
         name := "node",
-        overrideVersionSchemes,
         Compile / run / mainClass := Some("io.iohk.atala.prism.node.NodeApp")
       )
       .dependsOn(common % "compile->compile;test->test")
@@ -191,8 +189,7 @@ object PrismBuild {
           "io.iohk.atala.prism.connector.ConnectorApp"
         ),
         scalacOptions ~= (_ :+ "-Wconf:src=.*twirl/.*:silent"),
-        libraryDependencies += twirlApi,
-        overrideVersionSchemes
+        libraryDependencies += twirlApi
       )
       .dependsOn(common % "compile->compile;test->test")
       .enablePlugins(SbtTwirl)
@@ -204,8 +201,7 @@ object PrismBuild {
         resolvers += Resolver.sonatypeRepo("snapshots"),
         libraryDependencies ++= Seq(
           enumeratum
-        ),
-        overrideVersionSchemes
+        )
       )
       .dependsOn(common)
 
@@ -213,8 +209,7 @@ object PrismBuild {
     commonServerProject("vault")
       .settings(
         name := "vault",
-        Compile / run / mainClass := Some("io.iohk.atala.prism.vault.VaultApp"),
-        overrideVersionSchemes
+        Compile / run / mainClass := Some("io.iohk.atala.prism.vault.VaultApp")
       )
       .dependsOn(common % "compile->compile;test->test")
 
@@ -224,8 +219,7 @@ object PrismBuild {
         name := "management-console",
         Compile / run / mainClass := Some(
           "io.iohk.atala.prism.management.console.ManagementConsoleApp"
-        ),
-        overrideVersionSchemes
+        )
       )
       .dependsOn(common % "compile->compile;test->test")
 


### PR DESCRIPTION

Signed-off-by: Shailesh <shailesh.patil@iohk.io>

## Overview
Code cleanup removed the dependency scheme version for doobie was introduced for incompatibility 
 between the doobie-enumeratum and doobie 1.0.0-RC2

## Screenshots

## Checklists
<!-- Details you need to consider that are commonly forgotten -->

Pre-submit checklist:
- [x] Self-reviewed the diff
- [x] New code has proper comments/documentation/tests
- [x] Any changes not covered by tests have been tested manually
- [ ] The README files are updated
- [ ] If new libraries are included, they have licenses compatible with our project
- [ ] If there is a db migration altering existing tables, there is a proper migration test

Pre-merge checklist:
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
