### PR TITLE
ATA-6335: Fix version reported by GetNodeBuildInfo

### DIFF
--- a/prism-backend/project/PrismBuild.scala
+++ b/prism-backend/project/PrismBuild.scala
@@ -20,9 +20,8 @@ object PrismBuild {
       .settings(
         organization := "io.iohk",
         organizationName := "Input Output HK",
-        git.baseVersion := "1.2",
-        git.formattedShaVersion := git.gitHeadCommit.value
-          .map(git.baseVersion.value + "-" + _.take(8)),
+        git.baseVersion := "1.3",
+        git.useGitDescribe := true,
         scalaVersion := "2.13.7",
         scalacOptions ~= (options =>
           options.filterNot(


### PR DESCRIPTION
Config the sbt-git plugin so the project version comes from the git tag.
The plugin sbt-buildinfo should carry the version to GRPC method io.iohk.atala.prism.protos.NodeService/GetNodeBuildInfo

The version will be `version=<tag>-<n>-<short_hash>-<SNAPSHOT>` where
- `<tag.` is the last git tag.
- `<n>`  is the number of commits since the last tag.
- `<short_hash>` is the short hash SHA of the git HEAD.
- `<SNAPSHOT>` is if the git HEAD is not clean.

So on a release, the version is only the name of the git TAG.
An inconvenience of this is that we are not merging tags back to the master branch.   =(

We are interested when the commit is a TAG. 
The behavior will be identical to the version in the PRISM SDK when a TAG exists.

## Overview
<!-- What this PR does, and why is needed, a useful description is expected, and relevant tickets should be mentioned -->

## Screenshots
<!-- In case the PR involves UI changes, make sure to include success/failure related screenshots -->

## Checklists
<!-- Details you need to consider that are commonly forgotten -->

Pre-submit checklist:
- [x] Self-reviewed the diff
- [x] New code has proper comments/documentation/tests
- [x] Any changes not covered by tests have been tested manually
- [x] The README files are updated
- [ ] If new libraries are included, they have licenses compatible with our project
- [ ] If there is a db migration altering existing tables, there is a proper migration test

Pre-merge checklist:
- [x] Commits have useful messages
- [ ] Review clarifications made it into the code
