### PR TITLE
Added Operation Status for revocation

### DIFF
--- a/prism-backend/management-console/src/main/resources/db/migration/V20__add_revoke_operation_status.sql
+++ b/prism-backend/management-console/src/main/resources/db/migration/V20__add_revoke_operation_status.sql
@@ -1,0 +1,4 @@
+-- this property will be never set in the db it will populated dynamically
+ALTER TABLE published_credentials
+    ADD COLUMN revoked_on_operation_status TEXT NULL;
+

--- a/prism-backend/management-console/src/main/scala/io/iohk/atala/prism/management/console/grpc/ProtoCodecs.scala
+++ b/prism-backend/management-console/src/main/scala/io/iohk/atala/prism/management/console/grpc/ProtoCodecs.scala
@@ -5,6 +5,7 @@ import com.google.protobuf.ByteString
 import com.google.protobuf.timestamp.Timestamp
 import io.iohk.atala.prism.management.console.integrations.ContactsIntegrationService.DetailedContactWithConnection
 import io.iohk.atala.prism.management.console.models.{Contact, GenericCredential, InstitutionGroup, Statistics, _}
+import io.iohk.atala.prism.protos.common_models.OperationStatus.UNKNOWN_OPERATION
 import io.iohk.atala.prism.protos.console_api.GetContactResponse
 import io.iohk.atala.prism.protos.console_models.{ContactConnectionStatus, Group, StoredSignedCredential}
 import io.iohk.atala.prism.protos.{common_models, connector_models, console_api, console_models}
@@ -134,6 +135,7 @@ object ProtoCodecs {
       .withContactData(credential.contactData.noSpaces)
       .withConnectionStatus(connection.connectionStatus)
       .withExternalId(credential.externalId.value)
+      .withRevokedOnOperationStatus(toOperationStatus(credential.revokedOnOperationStatus))
       .withSharedAt(
         credential.sharedAt.map(_.toProtoTimestamp).getOrElse(Timestamp())
       )
@@ -148,6 +150,12 @@ object ProtoCodecs {
         .withBatchInclusionProof(data.inclusionProof.encode)
         .withPublicationStoredAt(data.storedAt.toProtoTimestamp)
     }
+  }
+
+  def toOperationStatus(
+      operationStatus: Option[OperationStatus]
+  ): common_models.OperationStatus = {
+    operationStatus.flatMap(os => common_models.OperationStatus.fromName(os.entryName)).getOrElse(UNKNOWN_OPERATION)
   }
 
   def toContactProto(

--- a/prism-backend/management-console/src/main/scala/io/iohk/atala/prism/management/console/models/GenericCredential.scala
+++ b/prism-backend/management-console/src/main/scala/io/iohk/atala/prism/management/console/models/GenericCredential.scala
@@ -2,6 +2,7 @@ package io.iohk.atala.prism.management.console.models
 
 import cats.data.NonEmptyList
 import derevo.derive
+import enumeratum.{DoobieEnum, Enum, EnumEntry}
 
 import java.time.{Instant, LocalDate}
 import java.util.UUID
@@ -72,6 +73,19 @@ case class PublicationData(
     storedAt: Instant // the time when the publication data was stored in the database
 )
 
+sealed abstract class OperationStatus(value: String) extends EnumEntry {
+  override def entryName: String = value
+}
+object OperationStatus extends Enum[OperationStatus] with DoobieEnum[OperationStatus] {
+  lazy val values = findValues
+
+  final case object UknownOperation extends OperationStatus("UNKNOWN_OPERATION")
+  final case object PendingSubmission extends OperationStatus("PENDING_SUBMISSION")
+  final case object AwaitConfirmation extends OperationStatus("AWAIT_CONFIRMATION")
+  final case object ConfirmAndApplied extends OperationStatus("CONFIRMED_AND_APPLIED")
+  final case object ConfirmAndRejected extends OperationStatus("CONFIRMED_AND_REJECTED")
+}
+
 final case class GenericCredential(
     credentialId: GenericCredential.Id,
     issuedBy: ParticipantId,
@@ -86,7 +100,8 @@ final case class GenericCredential(
     connectionToken: ConnectionToken,
     publicationData: Option[PublicationData],
     sharedAt: Option[Instant],
-    revokedOnOperationId: Option[AtalaOperationId]
+    revokedOnOperationId: Option[AtalaOperationId],
+    revokedOnOperationStatus: Option[OperationStatus]
 )
 
 object GenericCredential {

--- a/prism-backend/management-console/src/main/scala/io/iohk/atala/prism/management/console/repositories/daos/CredentialsDAO.scala
+++ b/prism-backend/management-console/src/main/scala/io/iohk/atala/prism/management/console/repositories/daos/CredentialsDAO.scala
@@ -29,7 +29,7 @@ object CredentialsDAO {
         |SELECT credential_id, c.issuer_id, c.contact_id, credential_data, c.created_at, c.credential_type_id,
         |       c.credential_issuance_contact_id, external_id, PTS.name AS issuer_name, contact_data, connection_token,
         |       PC.batch_id, PC.issuance_operation_hash, PC.issuance_operation_id, PC.encoded_signed_credential, PC.inclusion_proof,
-        |       PC.stored_at, PC.shared_at, PC.revoked_on_operation_id
+        |       PC.stored_at, PC.shared_at, PC.revoked_on_operation_id, PC.revoked_on_operation_status
       """.stripMargin
 
   private def withPublishedCredentialsPC(
@@ -40,7 +40,7 @@ object CredentialsDAO {
         fr"""
            |PC AS (
            |  SELECT credential_id, batch_id, issuance_operation_hash, issuance_operation_id, encoded_signed_credential, inclusion_proof,
-           |         stored_at, shared_at, revoked_on_operation_id
+           |         stored_at, shared_at, revoked_on_operation_id, revoked_on_operation_status
            |  FROM published_credentials JOIN published_batches USING (batch_id)
            |  WHERE credential_id = $credentialId
            |)
@@ -49,7 +49,7 @@ object CredentialsDAO {
         fr"""
           |PC AS (
           |  SELECT credential_id, batch_id, issuance_operation_hash, issuance_operation_id, encoded_signed_credential, inclusion_proof,
-          |         stored_at, shared_at, revoked_on_operation_id
+          |         stored_at, shared_at, revoked_on_operation_id, revoked_on_operation_status
           |  FROM published_credentials JOIN published_batches USING (batch_id)
           |)
           """.stripMargin
@@ -75,7 +75,7 @@ object CredentialsDAO {
     ) ++
       fr"""|SELECT inserted.*, contacts.external_id, PTS.name AS issuer_name, contacts.contact_data, connection_token,
            |       PC.batch_id, PC.issuance_operation_hash, PC.issuance_operation_id, PC.encoded_signed_credential, PC.inclusion_proof,
-           |       PC.stored_at, PC.shared_at, PC.revoked_on_operation_id
+           |       PC.stored_at, PC.shared_at, PC.revoked_on_operation_id, PC.revoked_on_operation_status
          |FROM inserted
          |     JOIN PTS USING (issuer_id)
          |     JOIN contacts ON (inserted.contact_id = contacts.contact_id)

--- a/prism-backend/management-console/src/test/scala/io/iohk/atala/prism/management/console/services/CredentialsServiceImplSpec.scala
+++ b/prism-backend/management-console/src/test/scala/io/iohk/atala/prism/management/console/services/CredentialsServiceImplSpec.scala
@@ -41,6 +41,8 @@ import scala.concurrent.Future
 import scala.jdk.CollectionConverters._
 import io.iohk.atala.prism.logging.TraceId
 import io.iohk.atala.prism.models.DidSuffix
+import io.iohk.atala.prism.protos.common_models.OperationStatus.UNKNOWN_OPERATION
+import io.iohk.atala.prism.protos.node_api.GetOperationInfoResponse
 import io.iohk.atala.prism.protos.node_models.OperationOutput
 
 class CredentialsServiceImplSpec extends ManagementConsoleRpcSpecBase with DIDUtil {
@@ -116,10 +118,14 @@ class CredentialsServiceImplSpec extends ManagementConsoleRpcSpecBase with DIDUt
             )
           )
         }
+        nodeMock.getOperationInfo(*).returns {
+          Future.successful(GetOperationInfoResponse().withOperationStatus(UNKNOWN_OPERATION))
+        }
 
         val response = serviceStub.getGenericCredentials(request)
         response.credentials.size must be(1)
         response.credentials.head.revokedOnOperationId.toByteArray must be(mockRevocationOperationId.value.toArray)
+        response.credentials.head.revokedOnOperationStatus must be(UNKNOWN_OPERATION)
       }
     }
 
@@ -655,12 +661,16 @@ class CredentialsServiceImplSpec extends ManagementConsoleRpcSpecBase with DIDUt
             )
           )
         }
-
+        nodeMock.getOperationInfo(*).returns {
+          Future.successful(GetOperationInfoResponse().withOperationStatus(UNKNOWN_OPERATION))
+        }
         val response = serviceStub.getContactCredentials(request)
         response.genericCredentials.size must be(1)
         response.genericCredentials.head.revokedOnOperationId.toByteArray must be(
           mockRevocationOperationId.value.toArray
         )
+        response.genericCredentials.head.revokedOnOperationStatus must be(UNKNOWN_OPERATION)
+
       }
     }
   }

--- a/prism-backend/project/Dependencies.scala
+++ b/prism-backend/project/Dependencies.scala
@@ -33,7 +33,7 @@ object versions {
   val typesafeConfig = "1.4.2"
   val http4s = "0.21.7"
   val fs2 = "3.2.5"
-  val prismSdk = "v1.3.3-snapshot-1651611967-8f35caa"
+  val prismSdk = "v1.3.3-snapshot-1651748276-f2fd995"
   val vaultSdk = "0.1.0-build-2-96cc137d"
 }
 


### PR DESCRIPTION
Signed-off-by: Shailesh <shailesh.patil@iohk.io>

## Overview
Add Operation Status for Revocation
Revocation status will be dynamically computed from Node getOperationInfo and return as part of GenericCredentials
## Screenshots

## Checklists
<!-- Details you need to consider that are commonly forgotten -->

Pre-submit checklist:
- [x] Self-reviewed the diff
- [x] New code has proper comments/documentation/tests
- [ ] Any changes not covered by tests have been tested manually
- [ ] The README files are updated
- [ ] If new libraries are included, they have licenses compatible with our project
- [ ] If there is a db migration altering existing tables, there is a proper migration test

Pre-merge checklist:
- [x] Commits have useful messages
- [ ] Review clarifications made it into the code
