### PR TITLE
ATL-611: Treat Cardano transactions which are in the Cardano memory pool as ongoing

### DIFF
--- a/prism-backend/node/src/main/scala/io/iohk/atala/prism/node/repositories/daos/AtalaObjectTransactionSubmissionsDAO.scala
+++ b/prism-backend/node/src/main/scala/io/iohk/atala/prism/node/repositories/daos/AtalaObjectTransactionSubmissionsDAO.scala
@@ -97,7 +97,7 @@ object AtalaObjectTransactionSubmissionsDAO {
              |SELECT tx.transaction_id, tx.ledger
              |FROM atala_object_tx_submissions AS tx
              |  INNER JOIN atala_objects AS obj ON tx.atala_object_id = obj.atala_object_id
-             |WHERE tx.status = 'IN_LEDGER' AND obj.atala_object_status = 'PENDING'
+             |WHERE (tx.status = 'PENDING' OR tx.status = 'IN_LEDGER') AND obj.atala_object_status = 'PENDING'
              |ORDER BY tx.submission_timestamp DESC
        """.stripMargin
       case Some(lastSeenId) =>
@@ -111,7 +111,7 @@ object AtalaObjectTransactionSubmissionsDAO {
              |FROM atala_object_tx_submissions AS tx
              |  INNER JOIN atala_objects AS obj ON tx.atala_object_id = obj.atala_object_id
              |  CROSS JOIN CTE
-             |WHERE tx.status = 'IN_LEDGER' AND obj.atala_object_status = 'PENDING' AND
+             |WHERE (tx.status = 'PENDING' OR tx.status = 'IN_LEDGER') AND obj.atala_object_status = 'PENDING' AND
              |       (tx.submission_timestamp < last_seen_time OR
                         tx.submission_timestamp = last_seen_time AND tx.transaction_id < $lastSeenId)
              |ORDER BY tx.submission_timestamp DESC, tx.transaction_id DESC

--- a/prism-backend/node/src/test/scala/io/iohk/atala/prism/node/repositories/daos/AtalaObjectTransactionSubmissionsDAOSpec.scala
+++ b/prism-backend/node/src/test/scala/io/iohk/atala/prism/node/repositories/daos/AtalaObjectTransactionSubmissionsDAOSpec.scala
@@ -9,7 +9,7 @@ import io.iohk.atala.prism.crypto.Sha256
 import io.iohk.atala.prism.models.Ledger.InMemory
 import io.iohk.atala.prism.models.{Ledger, TransactionId, TransactionInfo}
 import io.iohk.atala.prism.node.DataPreparation
-import io.iohk.atala.prism.node.models.AtalaObjectTransactionSubmissionStatus.InLedger
+import io.iohk.atala.prism.node.models.AtalaObjectTransactionSubmissionStatus.{InLedger, Pending}
 import io.iohk.atala.prism.node.models.{
   AtalaObjectId,
   AtalaObjectStatus,
@@ -361,7 +361,7 @@ class AtalaObjectTransactionSubmissionsDAOSpec extends AtalaWithPostgresSpec {
 
   private def insertTransactionSubmissions(
       objectIds: List[AtalaObjectId],
-      statuses: List[AtalaObjectTransactionSubmissionStatus] = List(InLedger, InLedger, InLedger)
+      statuses: List[AtalaObjectTransactionSubmissionStatus] = List(Pending, InLedger, InLedger)
   ): List[TransactionInfo] = {
     val txIds = (1 to objectIds.size)
       .map(idx => TransactionId.from(Sha256.compute(s"transactionId${idx + 1}".getBytes).getValue).value)


### PR DESCRIPTION
The problem is that we didn't take into the considerations transactions which have been created but haven't been submitted to the Cardano blockchain yet.

Because of that, there existed a gap between an object moved to AWAIT_CONFIRMATION state
and getWalletTransactions returning transaction for it.
This was considered weird so this gap is fixed by this commit.

## Overview
<!-- What this PR does, and why is needed, a useful description is expected, and relevant tickets should be mentioned -->

## Screenshots
<!-- In case the PR involves UI changes, make sure to include success/failure related screenshots -->

## Checklists
<!-- Details you need to consider that are commonly forgotten -->

Pre-submit checklist:
- [x] Self-reviewed the diff
- [ ] New code has proper comments/documentation/tests
- [x] Any changes not covered by tests have been tested manually
- [ ] The README files are updated
- [ ] If new libraries are included, they have licenses compatible with our project
- [ ] If there is a db migration altering existing tables, there is a proper migration test

Pre-merge checklist:
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
