### PR TITLE
[ATL-973] Publish images once and with latest tag for master on GitHub

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -196,8 +196,10 @@ jobs:
         run: |
           cd prism-backend
           export TAG="${{ steps.set-tag.outputs.tag }}"
+          if [[ "${{ github.ref }}" == "refs/heads/master" ]]; then
+            export PUBLISH_LATEST_TAG=true
+          fi
           sbt "${{ matrix.image }}/dockerBuildAndPush"
-          GITHUB=1 sbt "${{ matrix.image }}/dockerBuildAndPush"
       - name: Build and push prism-lb-envoy
         if: matrix.image == 'prism-lb-envoy'
         run: |


### PR DESCRIPTION
## Overview
<!-- What this PR does, and why is needed, a useful description is expected, and relevant tickets should be mentioned -->

Fixes ATL-973

Changes:
* Execute build and publish Docker images command once with different tags for AWS and Github
* Publishes `latest` tag for GitHub packages only if the `PUBLISH_LATEST_TAG` environment variable is set

## Checklists
<!-- Details you need to consider that are commonly forgotten -->

Pre-submit checklist:
- [x] Self-reviewed the diff
- [x] New code has proper comments/documentation/tests
- [x] Any changes not covered by tests have been tested manually
- [x] The README files are updated
- [x] If new libraries are included, they have licenses compatible with our project
- [x] If there is a db migration altering existing tables, there is a proper migration test

Pre-merge checklist:
- [x] Commits have useful messages
- [x] Review clarifications made it into the code
