### PR TITLE
Add GitHub workflow sbt-dependency-submission.yml

### DIFF
--- a/.github/workflows/sbt-dependency-submission.yml
+++ b/.github/workflows/sbt-dependency-submission.yml
@@ -1,0 +1,16 @@
+# See https://scala-lang.org/blog/2022/07/18/secure-your-dependencies-on-github.html
+# See https://github.com/marketplace/actions/sbt-dependency-submission
+name: Update Dependency Graph
+on:
+  push:
+    branches:
+      - master # default branch of the project
+jobs:
+  dependency-graph:
+    name: Update Dependency Graph
+    runs-on: ubuntu-latest # or windows-latest, or macOS-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: scalacenter/sbt-dependency-submission@v2
+        with:
+          working-directory: ./node/


### PR DESCRIPTION
## Overview
Scala Center released an SBT plugin & Github Action [sbt-dependency-submission](https://github.com/marketplace/actions/sbt-dependency-submission) that submits the dependencies of sbt builds to the [GitHub Dependency submission API](https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/using-the-dependency-submission-api).

See https://scala-lang.org/blog/2022/07/18/secure-your-dependencies-on-github.html
See https://github.com/marketplace/actions/sbt-dependency-submission

So now we have our dependencies (declared in sbt) checked by GitHub Dependabot!
