### PR TITLE
ATL-2835:  effectiveSince check should be greater than zero

### DIFF
--- a/prism-backend/node/src/main/scala/io/iohk/atala/prism/node/operations/ProtocolVersionUpdateOperation.scala
+++ b/prism-backend/node/src/main/scala/io/iohk/atala/prism/node/operations/ProtocolVersionUpdateOperation.scala
@@ -159,7 +159,7 @@ object ProtocolVersionUpdateOperation extends SimpleOperationCompanion[ProtocolV
       effectiveSince <-
         versionInfo
           .child(_.effectiveSince, "effectiveSince")
-          .parse(e => Either.cond(e >= 0, e, "Negative effectiveSince"))
+          .parse(e => Either.cond(e > 0, e, "Negative or zero effectiveSince"))
     } yield ProtocolVersionUpdateOperation(
       versionName,
       ProtocolVersion(major, minor),

--- a/prism-backend/node/src/test/scala/io/iohk/atala/prism/node/operations/ProtocolVersionUpdateOperationSpec.scala
+++ b/prism-backend/node/src/test/scala/io/iohk/atala/prism/node/operations/ProtocolVersionUpdateOperationSpec.scala
@@ -170,8 +170,24 @@ class ProtocolVersionUpdateOperationSpec extends AtalaWithPostgresSpec {
           "version",
           "effectiveSince"
         )
-        message mustBe "Negative effectiveSince"
+        message mustBe "Negative or zero effectiveSince"
       }
+    }
+  }
+
+  "return error when effectiveSince is zero" in {
+    val invalidOperation = protocolUpdateOperation(
+      ProtocolVersionInfo(ProtocolVersion(3, 3), None, 0)
+    )
+    inside(
+      ProtocolVersionUpdateOperation.parse(invalidOperation, dummyLedgerData)
+    ) { case Left(ValidationError.InvalidValue(path, _, message)) =>
+      path.path mustBe Vector(
+        "protocolVersionUpdate",
+        "version",
+        "effectiveSince"
+      )
+      message mustBe "Negative or zero effectiveSince"
     }
   }
 


### PR DESCRIPTION
## Overview
<!-- What this PR does, and why is needed, a useful description is expected, and relevant tickets should be mentioned -->
This PR changes the behavior of parsing "effectiveSince" in `ProtocolVersionUpdateOperation` to disallow numbers that are negative or 0 instead of just negative.

Also adds the test.

## Screenshots
<!-- In case the PR involves UI changes, make sure to include success/failure related screenshots -->

## Checklists
<!-- Details you need to consider that are commonly forgotten -->

Pre-submit checklist:
- [x] Self-reviewed the diff
- [ ] New code has proper comments/documentation/tests
- [ ] Any changes not covered by tests have been tested manually
- [ ] The README files are updated
- [ ] If new libraries are included, they have licenses compatible with our project
- [ ] If there is a db migration altering existing tables, there is a proper migration test

Pre-merge checklist:
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
