### PR TITLE
docs(node): Add old contributors list

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,23 @@
+# Contributors
+
+We would like to list here people who contributed to this project that may not be reflected in the commit history. In alphabetical order:
+
+- [AlexITC](https://github.com/AlexITC)
+- [amagyar-iohk](https://github.com/amagyar-iohk)
+- [antonbaliasnikov](https://github.com/antonbaliasnikov)
+- [CryptoKnightIOG](https://github.com/CryptoKnightIOG)
+- [esenese](https://github.com/esenese)
+- [EzequielPostan](https://github.com/EzequielPostan)
+- [FabioPinheiro](https://github.com/FabioPinheiro)
+- [itegulov](https://github.com/itegulov)
+- [KBabenkovScalac](https://github.com/KBabenkovScalac)
+- [krcz](https://github.com/krcz)
+- [loverdos](https://github.com/loverdos)
+- [milosbackonja](https://github.com/milosbackonja)
+- [mineme0110](https://github.com/mineme0110)
+- [pva701](https://github.com/pva701)
+- [shotexa](https://github.com/shotexa)
+- [vlad107](https://github.com/vlad107)
+- [wkoder](https://github.com/wkoder)
+- [zejaco](https://github.com/zejaco)
+


### PR DESCRIPTION
This PR adds the list of contributors for the Node repository. It includes github users that go beyond the commit history displayed in the repository today

## Overview
<!-- What this PR does, and why is needed, a useful description is expected, and relevant tickets should be mentioned -->

## Screenshots
<!-- In case the PR involves UI changes, make sure to include success/failure related screenshots -->

## Checklists
<!-- Details you need to consider that are commonly forgotten -->

Pre-submit checklist:
- [x] Self-reviewed the diff
- [x] New code has proper comments/documentation/tests
- [x] Any changes not covered by tests have been tested manually
- [x] The README files are updated
- [x] If new libraries are included, they have licenses compatible with our project
- [x] If there is a db migration altering existing tables, there is a proper migration test

Pre-merge checklist:
- [x] Commits have useful messages
- [x] Review clarifications made it into the code
