### PR TITLE
nodeoptimisation

### DIFF
--- a/src/main/scala/io/iohk/atala/prism/node/cardano/dbsync/CardanoDbSyncClient.scala
+++ b/src/main/scala/io/iohk/atala/prism/node/cardano/dbsync/CardanoDbSyncClient.scala
@@ -1,16 +1,19 @@
 package io.iohk.atala.prism.node.cardano.dbsync
 
 import cats.Comonad
-import cats.effect.{Async, Resource}
+import cats.effect.Async
+import cats.effect.Resource
+import io.iohk.atala.prism.node.cardano.dbsync.repositories.CardanoBlockRepository
+import io.iohk.atala.prism.node.cardano.models.Block
+import io.iohk.atala.prism.node.cardano.models.BlockError
 import io.iohk.atala.prism.node.metrics.TimeMeasureMetric
 import io.iohk.atala.prism.node.repositories.TransactorFactory
-import io.iohk.atala.prism.node.cardano.dbsync.repositories.CardanoBlockRepository
-import io.iohk.atala.prism.node.cardano.models.{Block, BlockError}
 import tofu.logging.Logs
 
 trait CardanoDbSyncClient[F[_]] {
   def getFullBlock(blockNo: Int): F[Either[BlockError.NotFound, Block.Full]]
   def getLatestBlock: F[Either[BlockError.NoneAvailable.type, Block.Canonical]]
+  def getAllPrismIndexBlocksWithTransactions(): F[Either[BlockError.NotFound, List[Block.Full]]]
 }
 
 final class CardanoDbSyncClientImpl[F[_]](
@@ -21,6 +24,9 @@ final class CardanoDbSyncClientImpl[F[_]](
 
   def getLatestBlock: F[Either[BlockError.NoneAvailable.type, Block.Canonical]] =
     cardanoBlockRepository.getLatestBlock
+
+  def getAllPrismIndexBlocksWithTransactions(): F[Either[BlockError.NotFound, List[Block.Full]]] =
+    cardanoBlockRepository.getAllPrismIndexBlocksWithTransactions()
 }
 
 object CardanoDbSyncClient {

--- a/src/main/scala/io/iohk/atala/prism/node/cardano/dbsync/repositories/CardanoBlockRepository.scala
+++ b/src/main/scala/io/iohk/atala/prism/node/cardano/dbsync/repositories/CardanoBlockRepository.scala
@@ -1,6 +1,8 @@
 package io.iohk.atala.prism.node.cardano.dbsync.repositories
 
-import cats.{Comonad, Functor}
+import cats.Comonad
+import cats.Functor
+import cats.effect.MonadCancelThrow
 import cats.syntax.comonad._
 import cats.syntax.either._
 import cats.syntax.functor._
@@ -8,21 +10,25 @@ import derevo.derive
 import derevo.tagless.applyK
 import doobie.implicits._
 import doobie.util.transactor.Transactor
-import io.iohk.atala.prism.node.metrics.TimeMeasureMetric
-import io.iohk.atala.prism.node.utils.syntax.DBConnectionOps
-import io.iohk.atala.prism.node.cardano.dbsync.repositories.daos.{BlockDAO, TransactionDAO}
+import io.iohk.atala.prism.node.cardano.dbsync.repositories.daos.BlockDAO
+import io.iohk.atala.prism.node.cardano.dbsync.repositories.daos.TransactionDAO
 import io.iohk.atala.prism.node.cardano.dbsync.repositories.logs.CardanoBlockRepositoryLogs
 import io.iohk.atala.prism.node.cardano.dbsync.repositories.metrics.CardanoBlockRepositoryMetrics
-import io.iohk.atala.prism.node.cardano.models.{Block, BlockError}
+import io.iohk.atala.prism.node.cardano.models.Block
+import io.iohk.atala.prism.node.cardano.models.BlockError
+import io.iohk.atala.prism.node.metrics.TimeMeasureMetric
+import io.iohk.atala.prism.node.utils.syntax.DBConnectionOps
 import tofu.higherKind.Mid
-import tofu.logging.{Logs, ServiceLogging}
+import tofu.logging.Logs
+import tofu.logging.ServiceLogging
 import tofu.syntax.monoid.TofuSemigroupOps
-import cats.effect.MonadCancelThrow
 
 @derive(applyK)
 trait CardanoBlockRepository[F[_]] {
   def getFullBlock(blockNo: Int): F[Either[BlockError.NotFound, Block.Full]]
   def getLatestBlock: F[Either[BlockError.NoneAvailable.type, Block.Canonical]]
+
+  def getAllPrismIndexBlocksWithTransactions(): F[Either[BlockError.NotFound, List[Block.Full]]]
 }
 
 object CardanoBlockRepository {
@@ -75,5 +81,22 @@ private final class CardanoBlockRepositoryImpl[F[_]: MonadCancelThrow](
           BlockError.NoneAvailable.asLeft
         )(header => Block.Canonical(header).asRight)
       )
+  }
+
+  def getAllPrismIndexBlocksWithTransactions(): F[Either[BlockError.NotFound, List[Block.Full]]] = {
+    BlockDAO
+      .findAllPrismIndex()
+      .map { results =>
+        Option.when(results.nonEmpty) {
+          results.map { case (header, transactions) =>
+            Block.Full(header, transactions)
+          }
+        }
+      }
+      .logSQLErrorsV2("getting all prism index blocks with transactions")
+      .transact(xa)
+      .map { result =>
+        result.toRight(BlockError.NotFound(0))
+      }
   }
 }

--- a/src/main/scala/io/iohk/atala/prism/node/cardano/dbsync/repositories/daos/BlockDAO.scala
+++ b/src/main/scala/io/iohk/atala/prism/node/cardano/dbsync/repositories/daos/BlockDAO.scala
@@ -2,8 +2,10 @@ package io.iohk.atala.prism.node.cardano.dbsync.repositories.daos
 
 import doobie.free.connection.ConnectionIO
 import doobie.implicits._
+import doobie.util.log.LogHandler
+import io.iohk.atala.prism.node.cardano.models.AtalaObjectMetadata
 import io.iohk.atala.prism.node.cardano.models.BlockHeader
-
+import io.iohk.atala.prism.node.cardano.models.Transaction
 private[repositories] object BlockDAO {
   def find(blockNo: Int): ConnectionIO[Option[BlockHeader]] = {
     sql"""
@@ -23,5 +25,57 @@ private[repositories] object BlockDAO {
            |ORDER BY b.block_no DESC
            |LIMIT 1
        """.stripMargin.query[BlockHeader].option
+  }
+
+  def findAllPrismIndex(): ConnectionIO[List[(BlockHeader, List[Transaction])]] = {
+
+    val query = sql"""
+      WITH block_data AS (
+        SELECT 
+          b.hash as block_hash,
+          b.block_no,
+          b.time as block_time,
+          tx.hash as tx_hash,
+          tx.block_index,
+          tx_metadata.key as metadata_key,
+          tx_metadata.json as metadata_json
+        FROM block b
+        LEFT JOIN tx ON tx.block_id = b.id
+        INNER JOIN tx_metadata ON tx_metadata.tx_id = tx.id 
+          AND tx_metadata.key = ${AtalaObjectMetadata.METADATA_PRISM_INDEX}
+        ORDER BY b.block_no, tx.block_index
+      )
+      SELECT * FROM block_data;
+    """.stripMargin
+    query
+      .queryWithLogHandler[BlockTransactionData](LogHandler.jdkLogHandler)
+      .to[List]
+      .map { results =>
+        results
+          .groupBy(row =>
+            BlockHeader(
+              hash = row.blockHash,
+              blockNo = row.blockNo,
+              time = row.time,
+              previousBlockHash = None // No previous block hash needed
+            )
+          )
+          .map { case (header, rows) =>
+            val transactions = rows
+              .map(row =>
+                Transaction(
+                  id = row.id,
+                  blockHash = row.blockHash,
+                  blockIndex = row.blockIndex,
+                  metadata = row.metadata
+                )
+              )
+              .toList
+
+            (header, transactions)
+          }
+          .toList
+          .sortBy(_._1.blockNo)
+      }
   }
 }

--- a/src/main/scala/io/iohk/atala/prism/node/cardano/dbsync/repositories/daos/package.scala
+++ b/src/main/scala/io/iohk/atala/prism/node/cardano/dbsync/repositories/daos/package.scala
@@ -1,15 +1,28 @@
 package io.iohk.atala.prism.node.cardano.dbsync.repositories
 
-import java.time.Instant
-
-import doobie.{Get, Read}
+import doobie.Get
+import doobie.Read
 import doobie.implicits.legacy.instant._
 import io.circe.Json
-import io.iohk.atala.prism.node.repositories.daos.BaseDAO
+import io.iohk.atala.prism.node.cardano.models.BlockHash
+import io.iohk.atala.prism.node.cardano.models.BlockHeader
+import io.iohk.atala.prism.node.cardano.models.Transaction
+import io.iohk.atala.prism.node.cardano.models.TransactionMetadata
 import io.iohk.atala.prism.node.models.TransactionId
-import io.iohk.atala.prism.node.cardano.models.{BlockHash, BlockHeader, Transaction, TransactionMetadata}
+import io.iohk.atala.prism.node.repositories.daos.BaseDAO
+
+import java.time.Instant
 
 package object daos extends BaseDAO {
+  case class BlockTransactionData(
+      blockHash: BlockHash,
+      blockNo: Int,
+      time: Instant,
+      id: TransactionId,
+      blockIndex: Int,
+      metadata: Option[TransactionMetadata]
+  )
+
   private[daos] implicit val blockHashGet: Get[BlockHash] =
     Get[Array[Byte]].tmap { bytes =>
       BlockHash
@@ -22,6 +35,39 @@ package object daos extends BaseDAO {
       .map((BlockHeader.apply _).tupled)
   }
 
+  private[daos] implicit val blockTransactionRead: Read[BlockTransactionData] = {
+    Read[(BlockHash, Int, Instant, TransactionId, Int, Option[Int], Option[String])]
+      .map {
+        case (
+              blockHash,
+              blockNo,
+              time,
+              transactionId,
+              blockIndex,
+              metadataKey,
+              metadataJson
+            ) =>
+          BlockTransactionData(
+            blockHash,
+            blockNo,
+            time,
+            transactionId,
+            blockIndex,
+            // Merge `metadataKey` and `metadataJson` columns into `TransactionMetadata`
+            metadataKey.map(key => {
+              val parsedMetadataJson = io.circe.parser
+                .parse(metadataJson.getOrElse("{}"))
+                .getOrElse(
+                  throw new RuntimeException(
+                    s"Metadata of transaction $transactionId could not be parsed"
+                  )
+                )
+
+              TransactionMetadata(Json.obj(key.toString -> parsedMetadataJson))
+            })
+          )
+      }
+  }
   private[daos] implicit val transactionRead: Read[Transaction] = {
     Read[(TransactionId, BlockHash, Int, Option[Int], Option[String])]
       .map {
@@ -51,4 +97,5 @@ package object daos extends BaseDAO {
           )
       }
   }
+
 }

--- a/src/main/scala/io/iohk/atala/prism/node/cardano/dbsync/repositories/logs/CardanoBlockRepositoryLogs.scala
+++ b/src/main/scala/io/iohk/atala/prism/node/cardano/dbsync/repositories/logs/CardanoBlockRepositoryLogs.scala
@@ -1,14 +1,15 @@
 package io.iohk.atala.prism.node.cardano.dbsync.repositories.logs
 
-import cats.syntax.apply._
+import cats.MonadThrow
 import cats.syntax.applicativeError._
+import cats.syntax.apply._
 import cats.syntax.flatMap._
 import io.iohk.atala.prism.node.cardano.dbsync.repositories.CardanoBlockRepository
-import io.iohk.atala.prism.node.cardano.models.{Block, BlockError}
+import io.iohk.atala.prism.node.cardano.models.Block
+import io.iohk.atala.prism.node.cardano.models.BlockError
 import tofu.higherKind.Mid
 import tofu.logging.ServiceLogging
 import tofu.syntax.logging._
-import cats.MonadThrow
 
 private[repositories] final class CardanoBlockRepositoryLogs[F[
     _
@@ -42,4 +43,15 @@ private[repositories] final class CardanoBlockRepositoryLogs[F[
         .onError(
           errorCause"Encountered an error while getting latest block" (_)
         )
+
+  override def getAllPrismIndexBlocksWithTransactions(): Mid[F, Either[BlockError.NotFound, List[Block.Full]]] =
+    in =>
+      info"getting all prism index blocks with transactions" *> in
+        .flatTap(
+          _.fold(
+            er => error"Encountered an error while getting all prism index blocks with transactions: $er",
+            res => info"getting all prism index blocks with headers ${res.map(_.header)} - successfully done"
+          )
+        )
+        .onError(errorCause"Encountered an error while getting all prism index blocks with transactions" (_))
 }

--- a/src/main/scala/io/iohk/atala/prism/node/cardano/dbsync/repositories/metrics/CardanoBlockRepositoryMetrics.scala
+++ b/src/main/scala/io/iohk/atala/prism/node/cardano/dbsync/repositories/metrics/CardanoBlockRepositoryMetrics.scala
@@ -1,10 +1,13 @@
 package io.iohk.atala.prism.node.cardano.dbsync.repositories.metrics
 
 import cats.effect.kernel.MonadCancel
-import io.iohk.atala.prism.node.metrics.{TimeMeasureMetric, TimeMeasureUtil}
-import io.iohk.atala.prism.node.metrics.TimeMeasureUtil.{DomainTimer, MeasureOps}
 import io.iohk.atala.prism.node.cardano.dbsync.repositories.CardanoBlockRepository
-import io.iohk.atala.prism.node.cardano.models.{Block, BlockError}
+import io.iohk.atala.prism.node.cardano.models.Block
+import io.iohk.atala.prism.node.cardano.models.BlockError
+import io.iohk.atala.prism.node.metrics.TimeMeasureMetric
+import io.iohk.atala.prism.node.metrics.TimeMeasureUtil
+import io.iohk.atala.prism.node.metrics.TimeMeasureUtil.DomainTimer
+import io.iohk.atala.prism.node.metrics.TimeMeasureUtil.MeasureOps
 import tofu.higherKind.Mid
 
 private[repositories] final class CardanoBlockRepositoryMetrics[F[_]: TimeMeasureMetric: MonadCancel[*[_], Throwable]]
@@ -15,6 +18,10 @@ private[repositories] final class CardanoBlockRepositoryMetrics[F[_]: TimeMeasur
     TimeMeasureUtil.createClientRequestTimer(repoName, "getFullBlock")
   val getLatestBlockTimer: DomainTimer =
     TimeMeasureUtil.createClientRequestTimer(repoName, "getLatestBlock")
+  val getBlockRangeWithTransactionsTimer: DomainTimer =
+    TimeMeasureUtil.createClientRequestTimer(repoName, "getBlockRangeWithTransactions")
+  val getAllPrismIndexBlocksWithTransactionsTimer: DomainTimer =
+    TimeMeasureUtil.createClientRequestTimer(repoName, "getAllPrismIndexBlocksWithTransactions")
 
   override def getFullBlock(
       blockNo: Int
@@ -23,4 +30,7 @@ private[repositories] final class CardanoBlockRepositoryMetrics[F[_]: TimeMeasur
 
   override def getLatestBlock: Mid[F, Either[BlockError.NoneAvailable.type, Block.Canonical]] =
     _.measureOperationTime(getLatestBlockTimer)
+
+  override def getAllPrismIndexBlocksWithTransactions(): Mid[F, Either[BlockError.NotFound, List[Block.Full]]] =
+    _.measureOperationTime(getAllPrismIndexBlocksWithTransactionsTimer)
 }

--- a/src/main/scala/io/iohk/atala/prism/node/cardano/logs/CardanoClientLogs.scala
+++ b/src/main/scala/io/iohk/atala/prism/node/cardano/logs/CardanoClientLogs.scala
@@ -28,6 +28,17 @@ private[cardano] final class CardanoClientLogs[
         )
         .onError(errorCause"Encountered an error while getting full block" (_))
 
+  override def getAllPrismIndexBlocksWithTransactions(): Mid[F, Either[BlockError.NotFound, List[Block.Full]]] =
+    in =>
+      info"getting all prism index blocks with transactions" *> in
+        .flatTap(
+          _.fold(
+            err => error"Encountered an error while getting all prism index blocks with transactions: $err",
+            blocks => info"getting all prism index blocks with headers ${blocks.map(_.header)}  - successfully done"
+          )
+        )
+        .onError(errorCause"Encountered an error while getting all prism index blocks with transactions" (_))
+
   override def getLatestBlock: Mid[F, Either[BlockError.NoneAvailable.type, Block.Canonical]] =
     in =>
       info"getting latest block" *> in

--- a/src/main/scala/io/iohk/atala/prism/node/repositories/daos/AtalaObjectsDAO.scala
+++ b/src/main/scala/io/iohk/atala/prism/node/repositories/daos/AtalaObjectsDAO.scala
@@ -3,11 +3,13 @@ package io.iohk.atala.prism.node.repositories.daos
 import cats.data.NonEmptyList
 import cats.syntax.functor._
 import doobie.Fragment
+import doobie.Fragments.in
 import doobie.free.connection
-import doobie.free.connection.{ConnectionIO, unit}
+import doobie.free.connection.ConnectionIO
+import doobie.free.connection.unit
 import doobie.implicits._
 import doobie.implicits.legacy.instant._
-import doobie.util.fragments.in
+import doobie.util.update.Update
 import io.iohk.atala.prism.node.models._
 
 import java.time.Instant
@@ -23,6 +25,80 @@ object AtalaObjectsDAO {
       objectId: AtalaObjectId,
       transactionInfo: TransactionInfo
   )
+  case class AtalaObjectCreateDataWithReceivedAt(
+      objectId: AtalaObjectId,
+      byteContent: Array[Byte],
+      status: AtalaObjectStatus
+  )
+
+  def insertMany(objects: List[AtalaObjectCreateData]): ConnectionIO[Int] = {
+    // Bulk insert objects
+    Update[(AtalaObjectId, Array[Byte], AtalaObjectStatus, Instant)](
+      """
+      INSERT INTO atala_objects (atala_object_id, object_content, atala_object_status, received_at)
+      VALUES (?, ?, ?, ?)
+      ON CONFLICT (atala_object_id) DO NOTHING
+      """
+    ).updateMany(objects.map(d => (d.objectId, d.byteContent, d.status, Instant.now())))
+  }
+
+  def setManyTransactionInfo(
+      data: List[AtalaObjectSetTransactionInfo]
+  ): ConnectionIO[Int] = {
+    // Extract valid transactions with blocks
+    val validTransactions = for {
+      item <- data
+      block <- item.transactionInfo.block.toList
+    } yield (
+      item.objectId,
+      item.transactionInfo.ledger,
+      block.number,
+      block.index,
+      block.timestamp,
+      item.transactionInfo.transactionId
+    )
+
+    // Log count before deduplication
+    println(s"INITIAL COUNT: Total of ${validTransactions.size} records before deduplication")
+
+    // Find duplicates by object ID
+    val groupedByObjectId = validTransactions.groupBy(_._1)
+    val duplicateGroups = groupedByObjectId.filter(_._2.size > 1)
+    val uniqueGroups = groupedByObjectId.filter(_._2.size == 1)
+
+    // Log detailed counts
+    println(s"DEDUPLICATION STATS:")
+    println(s"  Total input objects: ${data.size}")
+    println(s"  Valid transactions with blocks: ${validTransactions.size}")
+    println(s"  Unique object IDs: ${groupedByObjectId.size}")
+    println(s"  Objects with duplicates: ${duplicateGroups.size}")
+    println(s"  Objects without duplicates: ${uniqueGroups.size}")
+    println(s"  Total duplicate records: ${validTransactions.size - groupedByObjectId.size}")
+
+    // Log duplicates with full details
+    duplicateGroups.foreach { case (objectId, dupes) =>
+      println(s"DUPLICATE DETECTED for object ID: $objectId, found ${dupes.size} records:")
+      dupes.zipWithIndex.foreach { case (dupe, index) =>
+        println(s"  Duplicate #${index + 1}: $dupe")
+      }
+    }
+
+    // Keep only one record per object ID (the first one)
+    val dedupedTransactions = groupedByObjectId.map { case (_, txs) => txs.head }.toList
+
+    // Log final count after deduplication
+    println(s"FINAL COUNT: Total of ${dedupedTransactions.size} records after deduplication")
+    println(s"REMOVED: ${validTransactions.size - dedupedTransactions.size} duplicate records")
+
+    // Insert the unique transactions
+    Update[(AtalaObjectId, Ledger, Int, Int, Instant, TransactionId)](
+      """
+      INSERT INTO atala_object_txs 
+      (atala_object_id, ledger, block_number, block_index, block_timestamp, transaction_id)
+      VALUES (?, ?, ?, ?, ?, ?)
+      """
+    ).updateMany(dedupedTransactions)
+  }
 
   def insert(data: AtalaObjectCreateData): ConnectionIO[Int] = {
     sql"""
@@ -99,6 +175,23 @@ object AtalaObjectsDAO {
       .query[AtalaObjectInfo]
       .option
   }
+  // ??? Since we are syncing for first time this should be in processed status
+  def getProcessedObjectInfos: ConnectionIO[List[AtalaObjectInfo]] = {
+    sql"""
+         |SELECT obj.atala_object_id, obj.object_content, obj.atala_object_status,
+         |       tx.transaction_id, tx.ledger, tx.block_number, tx.block_timestamp, tx.block_index
+         |FROM
+         |(
+         |  SELECT *
+         |  FROM atala_objects AS obj
+         |  WHERE atala_object_status = 'PROCESSED'
+         |) as obj
+         |  LEFT OUTER JOIN atala_object_txs AS tx ON tx.atala_object_id = obj.atala_object_id
+         |ORDER BY tx.block_number ASC, tx.block_index ASC;
+       """.stripMargin
+      .query[AtalaObjectInfo]
+      .to[List]
+  }
 
   def getNotPublishedObjectInfos: ConnectionIO[List[AtalaObjectInfo]] = {
     sql"""
@@ -162,6 +255,23 @@ object AtalaObjectsDAO {
         fr"SET atala_object_status = $newStatus" ++
         fr"WHERE" ++ in(fr"atala_object_id", objectIdsNonEmpty)
       fragment.update.run.void
+    }
+  }
+
+  def getAtalaObjectsInfo(objectIds: List[AtalaObjectId]): ConnectionIO[List[AtalaObjectInfo]] = {
+    NonEmptyList.fromList(objectIds).fold(connection.pure(List.empty[AtalaObjectInfo])) { objectIdsNonEmpty =>
+      val q = fr"""
+        SELECT obj.atala_object_id, obj.object_content, obj.atala_object_status,
+               tx.transaction_id, tx.ledger, tx.block_number, tx.block_timestamp, tx.block_index
+        FROM atala_objects AS obj
+          LEFT OUTER JOIN atala_object_txs AS tx ON tx.atala_object_id = obj.atala_object_id
+        WHERE """ ++ in(
+        fr"obj.atala_object_id",
+        objectIdsNonEmpty
+      ) ++ fr" ORDER BY  tx.block_number ASC, tx.block_index ASC"
+
+      q.query[AtalaObjectInfo]
+        .to[List]
     }
   }
 }

--- a/src/main/scala/io/iohk/atala/prism/node/services/BlockProcessingService.scala
+++ b/src/main/scala/io/iohk/atala/prism/node/services/BlockProcessingService.scala
@@ -1,25 +1,36 @@
 package io.iohk.atala.prism.node.services
 
-import java.time.Instant
 import cats.data.EitherT
 import cats.implicits._
 import doobie.free.connection
 import doobie.free.connection.ConnectionIO
-import io.iohk.atala.prism.node.models.TimestampInfo
-import io.iohk.atala.prism.node.crypto.CryptoUtils.{SecpECDSA, SecpPublicKey}
-import io.iohk.atala.prism.node.models.{AtalaOperationId, Ledger, TransactionId}
+import io.iohk.atala.prism.node.crypto.CryptoUtils.SecpECDSA
+import io.iohk.atala.prism.node.crypto.CryptoUtils.SecpPublicKey
 import io.iohk.atala.prism.node.metrics.OperationsCounters
+import io.iohk.atala.prism.node.models.AtalaOperationId
 import io.iohk.atala.prism.node.models.AtalaOperationStatus
+import io.iohk.atala.prism.node.models.DidSuffix
+import io.iohk.atala.prism.node.models.Ledger
+import io.iohk.atala.prism.node.models.TimestampInfo
+import io.iohk.atala.prism.node.models.TransactionId
 import io.iohk.atala.prism.node.models.nodeState.LedgerData
 import io.iohk.atala.prism.node.operations._
 import io.iohk.atala.prism.node.repositories.daos.AtalaOperationsDAO
-import io.iohk.atala.prism.protos.node_models.SignedAtalaOperation
 import io.iohk.atala.prism.protos.node_models
+import io.iohk.atala.prism.protos.node_models.SignedAtalaOperation
 import org.slf4j.LoggerFactory
 
+import java.time.Instant
 import scala.util.chaining._
 import scala.util.control.NonFatal
 
+case class BlockProcessingInfo(
+    block: node_models.AtalaBlock,
+    transactionId: TransactionId,
+    ledger: Ledger,
+    blockTimestamp: Instant,
+    blockIndex: Int
+)
 // This service syncs Node state with the underlying ledger
 trait BlockProcessingService {
 
@@ -32,11 +43,186 @@ trait BlockProcessingService {
       blockTimestamp: Instant,
       blockIndex: Int
   ): ConnectionIO[Boolean]
+
+  // Process a batch of blocks in a single transaction
+  def processBlockBatch(
+      blocks: List[BlockProcessingInfo]
+  ): ConnectionIO[Boolean]
 }
 
 class BlockProcessingServiceImpl(applyOperationConfig: ApplyOperationConfig) extends BlockProcessingService {
   private val logger = LoggerFactory.getLogger(getClass)
 
+  override def processBlockBatch(
+      blocks: List[BlockProcessingInfo]
+  ): ConnectionIO[Boolean] = {
+    val methodName = "processBlockBatch"
+    println(s"processBlockBatch: Processing batch of ${blocks.size} blocks")
+    val (allInvalid, allValid) = blocks
+      .flatMap { blockInfo =>
+        val operations = blockInfo.block.operations.toList
+        val operationsWithSeqNumbers = operations.zipWithIndex
+        operationsWithSeqNumbers.map { case (signedOperation, index) =>
+          println(s"processBlockBatch: Processing operation ${index} of ${blockInfo.transactionId}")
+          parseOperation(
+            signedOperation,
+            LedgerData(
+              blockInfo.transactionId,
+              blockInfo.ledger,
+              TimestampInfo(blockInfo.blockTimestamp.toEpochMilli, blockInfo.blockIndex, index)
+            )
+          ) match {
+            case Left(err) => Left((blockInfo, signedOperation, err))
+            case Right(parsed) => Right((blockInfo, signedOperation, parsed))
+          }
+        }
+      }
+      .partitionMap(identity)
+
+    val seenDidKeys = scala.collection.mutable.HashSet[(DidSuffix, String)]()
+    val seenDidServices = scala.collection.mutable.HashSet[(DidSuffix, String)]()
+
+    val filteredAllValid: List[(BlockProcessingInfo, SignedAtalaOperation, Operation)] =
+      allValid.flatMap {
+        case (blockInfo, protoOp, op @ CreateDIDOperation(_, keys, services, _, _, _)) =>
+          val newKeys = keys.filter { key =>
+            val tuple = (key.didSuffix, key.keyId)
+            if (seenDidKeys.contains(tuple)) false
+            else {
+              seenDidKeys += tuple
+              true
+            }
+          }
+          val newServices = services.filter { service =>
+            val tuple = (service.didSuffix, service.id)
+            if (seenDidServices.contains(tuple)) false
+            else {
+              seenDidServices += tuple
+              true
+            }
+          }
+          if (newKeys.nonEmpty)
+            Some((blockInfo, protoOp, op.copy(keys = newKeys, services = newServices)))
+          else None
+
+        case (blockInfo, protoOp, op @ UpdateDIDOperation(didSuffix, actions, _, _, _)) =>
+          val newActions = actions.filter {
+            case AddKeyAction(key) =>
+              val tuple = (key.didSuffix, key.keyId)
+              if (seenDidKeys.contains(tuple)) false
+              else {
+                seenDidKeys += tuple
+                true
+              }
+            case AddServiceAction(service) =>
+              val tuple = (service.didSuffix, service.id)
+              if (seenDidServices.contains(tuple)) false
+              else {
+                seenDidServices += tuple
+                true
+              }
+            case _ => true
+          }
+          if (newActions.nonEmpty)
+            Some((blockInfo, protoOp, op.copy(actions = newActions)))
+          else None
+
+        case other => Some(other)
+      }
+    // // FOR DEBUGGING Only
+    // val allDidKeyTuples: List[(DidSuffix, String, String)] =
+    //   allValid.flatMap {
+    //     case (_, _, CreateDIDOperation(_, keys, services, _, _, _)) =>
+    //       keys.map(key => (key.didSuffix, key.keyId, "CreateDIDOperation")) ++
+    //         services.map(service => (service.didSuffix, service.id, "CreateDIDOperation.AddServiceAction"))
+    //     case (_, _, UpdateDIDOperation(_, actions, _, _, _)) =>
+    //       actions.collect {
+    //         case AddKeyAction(key) =>
+    //           (key.didSuffix, key.keyId, "UpdateDIDOperation.AddKeyAction")
+    //         case AddServiceAction(service) =>
+    //           (service.didSuffix, service.id, "UpdateDIDOperation.AddServiceAction")
+    //       }
+    //     case (_, _, DeactivateDIDOperation(didSuffix, _, _, _)) =>
+    //       List((didSuffix, "", "DeactivateDIDOperation"))
+    //     case _ => Nil
+    //   }
+    // println("****************************************************************************************************")
+    // println(s"allDidKeyTuples: ${allDidKeyTuples.mkString("\n")}")
+    // println("****************************************************************************************************")
+
+    for {
+      // Create a single savepoint for all blocks
+      savepoint <- connection.setSavepoint
+
+      // Process all Invalid operations in a batch
+      _ <- {
+        if (allInvalid.isEmpty) connection.unit
+        else {
+          val errMsg =
+            s"""
+                   | Found invalid operations in txId: ${allInvalid
+                .map(
+                  _._1.transactionId
+                )
+                .mkString(",")}, ledger: ${allInvalid.map(_._1.ledger).mkString(",")}
+                   | Operations:
+                   |    ${allInvalid
+                .map { case (_, op, err) => s"${err.render};\n\t${op.toProtoString.split("\n").mkString("\t\n")}" }
+                .mkString(";\n\n\t")}
+                   |""".stripMargin
+
+          logger.warn(errMsg)
+
+          AtalaOperationsDAO
+            .updateAtalaOperationStatusBatch(
+              allInvalid.map { case (_, op, _) => AtalaOperationId.of(op) },
+              AtalaOperationStatus.REJECTED
+            )
+        }
+      }
+
+      // Process all valid operations in a batch
+      opResults <- filteredAllValid.traverse { case (_, protoOperation, parsedOperation) =>
+        val atalaOperationId = AtalaOperationId.of(protoOperation)
+        for {
+          atalaOperationInfo <- AtalaOperationsDAO.getAtalaOperationInfo(atalaOperationId)
+          result <- processOperation(parsedOperation, protoOperation, atalaOperationId)
+          _ <- result match {
+            case Right(_) =>
+              logRequestWithContext(
+                methodName,
+                s"Operation applied:\n${parsedOperation.digest}",
+                atalaOperationId.toString,
+                protoOperation
+              )
+              OperationsCounters.countOperationApplied(protoOperation)
+              connection.unit
+            case Left(err) =>
+              logger.warn(
+                s"Operation was not applied:\n${err.toString}\nOperation:\n${protoOperation.toProtoString}"
+              )
+              OperationsCounters.countOperationRejected(protoOperation, err)
+              logRequestWithContext(
+                methodName,
+                s"Operation was not applied:\n${err.toString}",
+                atalaOperationId.toString,
+                protoOperation
+              )
+              if (atalaOperationInfo.exists(_.operationStatus != AtalaOperationStatus.APPLIED)) {
+                AtalaOperationsDAO.updateAtalaOperationStatus(
+                  atalaOperationId,
+                  AtalaOperationStatus.REJECTED,
+                  err.toString
+                )
+              } else connection.unit
+          }
+        } yield (atalaOperationId, result)
+      }
+
+      // If everything succeeded, release the savepoint
+      _ <- connection.releaseSavepoint(savepoint)
+    } yield opResults.exists(_._2.isRight)
+  }
   // ConnectionIO[Boolean] is a temporary type used to be able to unit tests this
   // it eventually will be replaced with ConnectionIO[Unit]
   override def processBlock(
@@ -49,7 +235,6 @@ class BlockProcessingServiceImpl(applyOperationConfig: ApplyOperationConfig) ext
     val methodName = "processBlock"
     val operations = block.operations.toList
     val operationsWithSeqNumbers = operations.zipWithIndex
-
     final case class ParsedOperations(
         valid: List[(SignedAtalaOperation, Operation)] = List.empty,
         invalid: List[(SignedAtalaOperation, ValidationError)] = List.empty
@@ -181,6 +366,7 @@ class BlockProcessingServiceImpl(applyOperationConfig: ApplyOperationConfig) ext
       _ <- EitherT.fromEither[ConnectionIO](
         verifySignature(key, protoOperation)
       )
+
       // Update Node's state
       _ <- operation.applyState(applyOperationConfig)
       // Set operation status to APPLIED

--- a/src/main/scala/io/iohk/atala/prism/node/services/CardanoLedgerService.scala
+++ b/src/main/scala/io/iohk/atala/prism/node/services/CardanoLedgerService.scala
@@ -1,28 +1,35 @@
 package io.iohk.atala.prism.node.services
 
-import cats.effect.{Resource, Temporal}
-import cats.syntax.applicative._
-import cats.syntax.applicativeError._
-import cats.syntax.comonad._
-import cats.syntax.flatMap._
-import cats.syntax.functor._
-import cats.syntax.traverse._
-import cats.{Applicative, Comonad, Functor, Monad}
-import enumeratum.{Enum, EnumEntry}
-import io.iohk.atala.prism.node.models._
+import cats.Applicative
+import cats.Comonad
+import cats.Functor
+import cats.Monad
+import cats.effect.Resource
+import cats.effect.Temporal
+import cats.syntax.all._
+import enumeratum.Enum
+import enumeratum.EnumEntry
+import io.iohk.atala.prism.node.PublicationInfo
+import io.iohk.atala.prism.node.UnderlyingLedger
+import io.iohk.atala.prism.node.cardano.CardanoClient
+import io.iohk.atala.prism.node.cardano.LAST_SYNCED_BLOCK_NO
+import io.iohk.atala.prism.node.cardano.LAST_SYNCED_BLOCK_TIMESTAMP
 import io.iohk.atala.prism.node.cardano.models.Block.Canonical
 import io.iohk.atala.prism.node.cardano.models._
-import io.iohk.atala.prism.node.cardano.{CardanoClient, LAST_SYNCED_BLOCK_NO, LAST_SYNCED_BLOCK_TIMESTAMP}
 import io.iohk.atala.prism.node.models.Balance
+import io.iohk.atala.prism.node.models._
 import io.iohk.atala.prism.node.repositories.daos.KeyValuesDAO.KeyValue
-import io.iohk.atala.prism.node.services.CardanoLedgerService.{CardanoBlockHandler, CardanoNetwork}
+import io.iohk.atala.prism.node.services.CardanoLedgerService.CardanoBlockHandler
+import io.iohk.atala.prism.node.services.CardanoLedgerService.CardanoNetwork
 import io.iohk.atala.prism.node.services.logs.UnderlyingLedgerLogs
-import io.iohk.atala.prism.node.services.models.{AtalaObjectNotification, AtalaObjectNotificationHandler}
-import io.iohk.atala.prism.node.{PublicationInfo, UnderlyingLedger}
+import io.iohk.atala.prism.node.services.models.AtalaObjectBulkNotificationHandler
+import io.iohk.atala.prism.node.services.models.AtalaObjectNotification
+import io.iohk.atala.prism.node.services.models.AtalaObjectNotificationHandler
 import io.iohk.atala.prism.protos.node_models
 import tofu.higherKind.Mid
 import tofu.lift.Lift
-import tofu.logging.{Logs, ServiceLogging}
+import tofu.logging.Logs
+import tofu.logging.ServiceLogging
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
@@ -61,7 +68,8 @@ class CardanoLedgerService[F[_]] private[services] (
     cardanoClient: CardanoClient[F],
     keyValueService: KeyValueService[F],
     onCardanoBlock: CardanoBlockHandler[F],
-    onAtalaObject: AtalaObjectNotificationHandler[F]
+    onAtalaObject: AtalaObjectNotificationHandler[F],
+    onAtalaObjectBulk: AtalaObjectBulkNotificationHandler[F]
 )(implicit
     timer: Temporal[F],
     liftToFuture: Lift[F, Future]
@@ -157,10 +165,23 @@ class CardanoLedgerService[F[_]] private[services] (
         maybeLastSyncedBlockNo,
         blockNumberSyncStart
       )
+
+      _ <-
+        if (lastSyncedBlockNo == (blockNumberSyncStart - 1)) {
+          bulkSyncBlocks()
+        } else {
+          Monad[F].pure(())
+        }
+      maybeLastSyncedBlockNo <- keyValueService.getInt(LAST_SYNCED_BLOCK_NO)
+      // Calculates the next block based on the initial `blockNumberSyncStart` and the latest synced block.
+      lastSyncedBlockNo = CardanoLedgerService.calculateLastSyncedBlockNo(
+        maybeLastSyncedBlockNo,
+        blockNumberSyncStart
+      )
       // Gets the latest block from the Cardano database.
-      latestBlock <- cardanoClient.getLatestBlock
+      latestBlockOpt <- cardanoClient.getLatestBlock
       // Calculates the latest confirmed block based on amount of required confirmations.
-      lastConfirmedBlockNo = latestBlock.map(
+      lastConfirmedBlockNo = latestBlockOpt.map(
         _.header.blockNo - blockConfirmationsToWait
       )
       syncStart = lastSyncedBlockNo + 1
@@ -173,6 +194,77 @@ class CardanoLedgerService[F[_]] private[services] (
     } yield lastConfirmedBlockNo
       .flatMap(last => syncEnd.map(last > _))
       .getOrElse(false)
+  }
+
+  private def bulkSyncBlocks(): F[Unit] = {
+    for {
+      blocksEit <- cardanoClient.getAllPrismIndexBlocksWithTransactions()
+      _ <- blocksEit.fold(
+        _ => Monad[F].pure(()),
+        blocks =>
+          for {
+            // Bulk process all Atala objects
+            _ <- bulkProcessAtalaObjects(blocks)
+            // Gets the latest block from the Cardano database.
+            latestBlockOpt <- cardanoClient.getLatestBlock
+            // Calculates the latest confirmed block based on amount of required confirmations.
+            lastConfirmedBlockNo = latestBlockOpt.map(
+              _.header.blockNo - blockConfirmationsToWait
+            )
+
+            _ <- lastConfirmedBlockNo match {
+              case Right(value) =>
+                cardanoClient.getFullBlock(value).flatMap {
+                  case Right(confirmedBlock) => {
+                    updateLastSyncedBlock(confirmedBlock)
+                  }
+                  case Left(_) => {
+                    updateLastSyncedBlock(blocks.last)
+                  }
+                }
+              case Left(_) => {
+                updateLastSyncedBlock(blocks.last)
+              }
+            }
+          } yield ()
+      )
+    } yield ()
+  }
+
+  private def bulkProcessAtalaObjects(blocks: List[Block.Full]): F[Unit] = {
+    // Collect all notifications from blocks
+    val notifications: List[AtalaObjectNotification] = blocks.flatMap { block =>
+      block.transactions.flatMap { transaction =>
+        transaction.metadata.flatMap { metadata =>
+          AtalaObjectMetadata.fromTransactionMetadata(metadata).map { atalaObject =>
+            AtalaObjectNotification(
+              atalaObject,
+              TransactionInfo(
+                transactionId = transaction.id,
+                ledger = getType,
+                block = Some(
+                  BlockInfo(
+                    number = block.header.blockNo,
+                    timestamp = block.header.time,
+                    index = transaction.blockIndex
+                  )
+                )
+              )
+            )
+          }
+        }
+      }
+    }
+
+    val batchSize = 5000 // TODO: make it configurable
+
+    // notifications.grouped(batchSize).toList.traverse_(onAtalaObjectBulk)
+    notifications.grouped(batchSize).toList.traverse_ { batch =>
+      println(
+        s"Processing ${batch.size} notifications in batches of size: ${batch.size}"
+      )
+      onAtalaObjectBulk(batch)
+    }
   }
 
   // Sync blocks in the given range.
@@ -290,6 +382,7 @@ object CardanoLedgerService {
       keyValueService: KeyValueService[F],
       onCardanoBlock: CardanoBlockHandler[F],
       onAtalaObject: AtalaObjectNotificationHandler[F],
+      onAtalaObjectBulk: AtalaObjectBulkNotificationHandler[F],
       logs: Logs[R, F]
   ): R[UnderlyingLedger[F]] =
     for {
@@ -309,7 +402,8 @@ object CardanoLedgerService {
         cardanoClient,
         keyValueService,
         onCardanoBlock,
-        onAtalaObject
+        onAtalaObject,
+        onAtalaObjectBulk
       )
     }
 
@@ -319,6 +413,7 @@ object CardanoLedgerService {
       keyValueService: KeyValueService[F],
       onCardanoBlock: CardanoBlockHandler[F],
       onAtalaObject: AtalaObjectNotificationHandler[F],
+      onAtalaObjectBulk: AtalaObjectBulkNotificationHandler[F],
       logs: Logs[R, F]
   ): Resource[R, UnderlyingLedger[F]] = {
     val walletId = WalletId
@@ -343,6 +438,7 @@ object CardanoLedgerService {
         keyValueService,
         onCardanoBlock,
         onAtalaObject,
+        onAtalaObjectBulk,
         logs
       )
     )
@@ -354,6 +450,7 @@ object CardanoLedgerService {
       keyValueService: KeyValueService[F],
       onCardanoBlock: CardanoBlockHandler[F],
       onAtalaObject: AtalaObjectNotificationHandler[F],
+      onAtalaObjectBulk: AtalaObjectBulkNotificationHandler[F],
       logs: Logs[R, F]
   ): UnderlyingLedger[F] = {
     val walletId = WalletId
@@ -377,6 +474,7 @@ object CardanoLedgerService {
       keyValueService,
       onCardanoBlock,
       onAtalaObject,
+      onAtalaObjectBulk,
       logs
     ).extract
   }

--- a/src/main/scala/io/iohk/atala/prism/node/services/ObjectManagementService.scala
+++ b/src/main/scala/io/iohk/atala/prism/node/services/ObjectManagementService.scala
@@ -1,51 +1,64 @@
 package io.iohk.atala.prism.node.services
 
+import cats.Applicative
+import cats.ApplicativeError
+import cats.Comonad
+import cats.Functor
+import cats.Monad
 import cats.data.EitherT
-import cats.effect.{MonadCancelThrow, Resource}
+import cats.effect.MonadCancelThrow
+import cats.effect.Resource
 import cats.syntax.comonad._
 import cats.syntax.either._
 import cats.syntax.traverse._
-import cats.{Applicative, ApplicativeError, Comonad, Functor, Monad}
 import derevo.derive
 import derevo.tagless.applyK
 import doobie.free.connection.ConnectionIO
 import doobie.implicits._
 import doobie.util.transactor.Transactor
-import io.iohk.atala.prism.node.models.{AtalaOperationId, TransactionId, TransactionInfo}
 import io.iohk.atala.prism.node.cardano.LAST_SYNCED_BLOCK_TIMESTAMP
 import io.iohk.atala.prism.node.errors.NodeError
-import io.iohk.atala.prism.node.errors.NodeError.{InvalidArgument, UnsupportedProtocolVersion}
+import io.iohk.atala.prism.node.errors.NodeError.InvalidArgument
+import io.iohk.atala.prism.node.errors.NodeError.UnsupportedProtocolVersion
 import io.iohk.atala.prism.node.metrics.OperationsCounters
 import io.iohk.atala.prism.node.models.AtalaObjectTransactionSubmissionStatus.InLedger
+import io.iohk.atala.prism.node.models.AtalaOperationId
+import io.iohk.atala.prism.node.models.TransactionId
+import io.iohk.atala.prism.node.models.TransactionInfo
 import io.iohk.atala.prism.node.models._
 import io.iohk.atala.prism.node.models.nodeState.getLastSyncedTimestampFromMaybe
+import io.iohk.atala.prism.node.operations.CreateDIDOperation
+import io.iohk.atala.prism.node.operations.parseOperationWithMockedLedger
 import io.iohk.atala.prism.node.operations.protocolVersion.SUPPORTED_VERSION
-import io.iohk.atala.prism.node.operations.{CreateDIDOperation, parseOperationWithMockedLedger}
+import io.iohk.atala.prism.node.repositories.AtalaObjectsTransactionsRepository
+import io.iohk.atala.prism.node.repositories.AtalaOperationsRepository
+import io.iohk.atala.prism.node.repositories.KeyValuesRepository
+import io.iohk.atala.prism.node.repositories.ProtocolVersionRepository
+import io.iohk.atala.prism.node.repositories.daos.AtalaObjectTransactionSubmissionsDAO
 import io.iohk.atala.prism.node.repositories.daos.AtalaObjectsDAO
-import io.iohk.atala.prism.node.repositories.{
-  AtalaObjectsTransactionsRepository,
-  AtalaOperationsRepository,
-  KeyValuesRepository,
-  ProtocolVersionRepository
-}
 import io.iohk.atala.prism.node.services.ObjectManagementService.SaveObjectError
 import io.iohk.atala.prism.node.services.logs.ObjectManagementServiceLogs
 import io.iohk.atala.prism.node.services.models.AtalaObjectNotification
-import io.iohk.atala.prism.protos.node_models.SignedAtalaOperation
-import io.iohk.atala.prism.protos.node_models
 import io.iohk.atala.prism.node.utils.syntax.DBConnectionOps
+import io.iohk.atala.prism.protos.node_models
+import io.iohk.atala.prism.protos.node_models.SignedAtalaOperation
 import tofu.higherKind.Mid
+import tofu.logging.Logs
+import tofu.logging.ServiceLogging
 import tofu.logging.derivation.loggable
-import tofu.logging.{Logs, ServiceLogging}
 import tofu.syntax.feither._
 import tofu.syntax.monadic._
-
+import org.slf4j.LoggerFactory
 import java.time.Instant
 
 @derive(applyK)
 trait ObjectManagementService[F[_]] {
   def saveObject(
       notification: AtalaObjectNotification
+  ): F[Either[SaveObjectError, Boolean]]
+
+  def saveObjects(
+      notifications: List[AtalaObjectNotification]
   ): F[Either[SaveObjectError, Boolean]]
 
   def scheduleAtalaOperations(
@@ -83,6 +96,186 @@ private final class ObjectManagementServiceImpl[F[_]: MonadCancelThrow](
     didServicesLimit: Int,
     xa: Transactor[F]
 ) extends ObjectManagementService[F] {
+  private val logger = LoggerFactory.getLogger(getClass)
+
+  def saveObjects2(
+      notifications: List[AtalaObjectNotification]
+  ): F[Either[SaveObjectError, Boolean]] = {
+    if (notifications.isEmpty) {
+      true.asRight[SaveObjectError].pure[F]
+    } else {
+
+      def applyTransactions(atalaObjectInfos: List[AtalaObjectInfo]): F[Either[SaveObjectError, Boolean]] = {
+        for {
+          // Process all objects and apply them to the state
+          transactions <- atalaObjectInfos.traverse { case (obj) =>
+            Monad[F].pure(processObject(obj))
+          }
+          result <- transactions.sequence.flatTraverse { txs =>
+            txs
+              .traverse(_.logSQLErrorsV2("Transaction saving objects").attemptSql)
+              .transact(xa)
+              .map(_.sequence)
+              .map(_.map(_ => true))
+              .leftMapIn(err => SaveObjectError(err.getMessage))
+          }
+
+        } yield result
+      }
+
+      def processObjectList(
+          notifications: List[AtalaObjectNotification]
+      ): F[Either[SaveObjectError, Boolean]] = {
+        val pairedInserts: List[
+          (AtalaObjectId, AtalaObjectsDAO.AtalaObjectCreateData, AtalaObjectsDAO.AtalaObjectSetTransactionInfo)
+        ] =
+          notifications.map { notification =>
+            val objectBytes = notification.atalaObject.toByteArray
+            val objId = AtalaObjectId.of(objectBytes)
+            (
+              objId,
+              AtalaObjectsDAO.AtalaObjectCreateData(
+                objId,
+                objectBytes,
+                AtalaObjectStatus.Processed
+              ),
+              AtalaObjectsDAO.AtalaObjectSetTransactionInfo(
+                objId,
+                notification.transaction
+              )
+            )
+          }
+
+        val (objectIds, objectInserts, transactionInserts) = pairedInserts.unzip3
+
+        // Bulk database operations
+        val bulkQuery = for {
+          count1 <- AtalaObjectsDAO.insertMany(objectInserts)
+          count2 <- AtalaObjectsDAO.setManyTransactionInfo(transactionInserts)
+          count3 <- AtalaObjectTransactionSubmissionsDAO
+            .updateStatusBatch(
+              transactionInserts.map(d =>
+                (
+                  d.transactionInfo.ledger,
+                  d.transactionInfo.transactionId,
+                  AtalaObjectTransactionSubmissionStatus.InLedger
+                )
+              )
+            )
+          atalaObjectsInfo <- AtalaObjectsDAO.getAtalaObjectsInfo(objectIds)
+        } yield (count1, count2, count3, atalaObjectsInfo)
+
+        bulkQuery
+          .logSQLErrorsV2("bulk processing atala objects")
+          .attemptSql
+          .transact(xa)
+          .flatMap {
+            case Left(err) => SaveObjectError(err.getMessage).asLeft[Boolean].pure[F]
+            case Right((count1, count2, count3, atalaObjectsInfo)) =>
+              if (
+                count1 != objectInserts.size || count2 != transactionInserts.size || count3 != transactionInserts.size
+              ) {
+                logger.info(
+                  s"Count mismatches: Create(exp=${objectInserts.size},got=$count1), " +
+                    s"TxInfo(exp=${transactionInserts.size},got=$count2), " +
+                    s"Status(exp=${transactionInserts.size},got=$count3)"
+                )
+              }
+              // Apply transactions to the state finally this sequencial operation similar to applyTransaction
+              applyTransactions(atalaObjectsInfo)
+          }
+      }
+
+      processObjectList(notifications)
+    }
+  }
+
+  def saveObjects(
+      notifications: List[AtalaObjectNotification]
+  ): F[Either[SaveObjectError, Boolean]] = {
+    if (notifications.isEmpty) {
+      true.asRight[SaveObjectError].pure[F]
+    } else {
+
+      def applyTransactions(atalaObjectInfos: List[AtalaObjectInfo]): F[Either[SaveObjectError, Boolean]] = {
+        processObjects(atalaObjectInfos) match {
+          case Left(err) => err.asLeft[Boolean].pure[F]
+          case Right(io) =>
+            io.attemptSql.transact(xa).map {
+              case Left(e) =>
+                SaveObjectError(e.getMessage).asLeft[Boolean]
+              case Right(result) =>
+                result.asRight[SaveObjectError]
+            }
+        }
+      }
+
+      def processObjectList(
+          notifications: List[AtalaObjectNotification]
+      ): F[Either[SaveObjectError, Boolean]] = {
+        val pairedInserts: List[
+          (AtalaObjectId, AtalaObjectsDAO.AtalaObjectCreateData, AtalaObjectsDAO.AtalaObjectSetTransactionInfo)
+        ] =
+          notifications.map { notification =>
+            val objectBytes = notification.atalaObject.toByteArray
+            val objId = AtalaObjectId.of(objectBytes)
+            (
+              objId,
+              AtalaObjectsDAO.AtalaObjectCreateData(
+                objId,
+                objectBytes,
+                AtalaObjectStatus.Processed
+              ),
+              AtalaObjectsDAO.AtalaObjectSetTransactionInfo(
+                objId,
+                notification.transaction
+              )
+            )
+          }
+
+        val (objectIds, objectInserts, transactionInserts) = pairedInserts.unzip3
+
+        // Bulk database operations
+        val bulkQuery = for {
+          count1 <- AtalaObjectsDAO.insertMany(objectInserts)
+          count2 <- AtalaObjectsDAO.setManyTransactionInfo(transactionInserts)
+          count3 <- AtalaObjectTransactionSubmissionsDAO
+            .updateStatusBatch(
+              transactionInserts.map(d =>
+                (
+                  d.transactionInfo.ledger,
+                  d.transactionInfo.transactionId,
+                  AtalaObjectTransactionSubmissionStatus.InLedger
+                )
+              )
+            )
+          atalaObjectsInfo <- AtalaObjectsDAO.getAtalaObjectsInfo(objectIds)
+        } yield (count1, count2, count3, atalaObjectsInfo)
+
+        bulkQuery
+          .logSQLErrorsV2("bulk processing atala objects")
+          .attemptSql
+          .transact(xa)
+          .flatMap {
+            case Left(err) => SaveObjectError(err.getMessage).asLeft[Boolean].pure[F]
+            case Right((count1, count2, count3, atalaObjectsInfo)) =>
+              if (
+                count1 != objectInserts.size || count2 != transactionInserts.size || count3 != transactionInserts.size
+              ) {
+                println(
+                  s"Count mismatches: Create(exp=${objectInserts.size},got=$count1), " +
+                    s"TxInfo(exp=${transactionInserts.size},got=$count2), " +
+                    s"Status(exp=${transactionInserts.size},got=$count3)"
+                )
+              }
+              // Apply transactions to the state finally this sequencial operation similar to applyTransaction
+              applyTransactions(atalaObjectsInfo)
+          }
+      }
+
+      processObjectList(notifications)
+    }
+  }
 
   // Processes AtalaObjects retrieved from transaction metadata during the Node syncing with Cardano Ledger
   def saveObject(
@@ -255,6 +448,63 @@ private final class ObjectManagementServiceImpl[F[_]: MonadCancelThrow](
       .getOperationInfo(atalaOperationId)
       .map(_.toOption.flatten)
 
+  private def processObjects(
+      objs: List[AtalaObjectInfo]
+  ): Either[SaveObjectError, ConnectionIO[Boolean]] = {
+    // Parse all objects, collecting errors and valid BlockInfos
+    val parsed: List[Either[SaveObjectError, (BlockProcessingInfo, AtalaObjectInfo)]] = objs.map { obj =>
+      for {
+        protobufObject <-
+          Either
+            .fromTry(node_models.AtalaObject.validate(obj.byteContent))
+            .leftMap(err => SaveObjectError(err.getMessage))
+        result <- protobufObject.blockContent match {
+          case Some(block) =>
+            for {
+              transactionInfo <- Either.fromOption(
+                obj.transaction,
+                SaveObjectError("AtalaObject has no transaction info")
+              )
+              transactionBlock <- Either.fromOption(
+                transactionInfo.block,
+                SaveObjectError("AtalaObject has no transaction block")
+              )
+            } yield (
+              BlockProcessingInfo(
+                block,
+                transactionInfo.transactionId,
+                transactionInfo.ledger,
+                transactionBlock.timestamp,
+                transactionBlock.index
+              ),
+              obj
+            )
+          case None =>
+            val msg =
+              s"processObjects: blockContent is None for object: ${obj.objectId} transaction: ${obj.transaction}"
+            Left(SaveObjectError(msg))
+        }
+      } yield result
+    }
+
+    // Separate errors and valid parses
+    val (errors, valid) = parsed.partitionMap(identity)
+    val blockInfos = valid.map(_._1)
+    val validObjs = valid.map(_._2)
+
+    if (blockInfos.isEmpty)
+      Left(errors.headOption.getOrElse(SaveObjectError("No valid objects to process")))
+    else
+      Right(
+        for {
+          wasProcessed <- blockProcessing.processBlockBatch(blockInfos) // TODO: Batch processing below
+          _ <- AtalaObjectsDAO.updateObjectStatusBatch(
+            validObjs.map(_.objectId),
+            AtalaObjectStatus.Processed
+          )
+        } yield wasProcessed
+      )
+  }
   // Retrieves operations from the object, and applies them to the state
   private def processObject(
       obj: AtalaObjectInfo

--- a/src/main/scala/io/iohk/atala/prism/node/services/logs/ObjectManagementServiceLogs.scala
+++ b/src/main/scala/io/iohk/atala/prism/node/services/logs/ObjectManagementServiceLogs.scala
@@ -32,6 +32,19 @@ private[services] class ObjectManagementServiceLogs[
         }
         .onError(errorCause"Encountered an error while saving object" (_))
 
+  def saveObjects(
+      notifications: List[AtalaObjectNotification]
+  ): Mid[F, Either[SaveObjectError, Boolean]] =
+    in =>
+      info"saving objects included in transactions ${notifications.map(_.transaction)}" *> in
+        .flatTap {
+          _.fold(
+            err => error"saving objects - failed cause: $err",
+            res => info"saving objects - successfully done, result: $res"
+          )
+        }
+        .onError(errorCause"Encountered an error while saving objects" (_))
+
   def scheduleAtalaOperations(
       ops: SignedAtalaOperation*
   ): Mid[F, List[Either[errors.NodeError, AtalaOperationId]]] =

--- a/src/main/scala/io/iohk/atala/prism/node/services/models/package.scala
+++ b/src/main/scala/io/iohk/atala/prism/node/services/models/package.scala
@@ -2,20 +2,18 @@ package io.iohk.atala.prism.node.services
 
 import cats.implicits._
 import derevo.derive
-import io.iohk.atala.prism.node.models.TransactionInfo
 import io.iohk.atala.prism.node.errors.NodeError
-import io.iohk.atala.prism.node.operations.{
-  CreateDIDOperation,
-  DeactivateDIDOperation,
-  ProtocolVersionUpdateOperation,
-  UpdateDIDOperation,
-  ValidationError,
-  parseOperationWithMockedLedger
-}
-import io.iohk.atala.prism.protos.node_models
+import io.iohk.atala.prism.node.models.TransactionInfo
+import io.iohk.atala.prism.node.operations.CreateDIDOperation
+import io.iohk.atala.prism.node.operations.DeactivateDIDOperation
+import io.iohk.atala.prism.node.operations.ProtocolVersionUpdateOperation
+import io.iohk.atala.prism.node.operations.UpdateDIDOperation
+import io.iohk.atala.prism.node.operations.ValidationError
+import io.iohk.atala.prism.node.operations.parseOperationWithMockedLedger
 import io.iohk.atala.prism.protos.node_api
-import io.iohk.atala.prism.protos.node_models.SignedAtalaOperation
 import io.iohk.atala.prism.protos.node_api.OperationOutput
+import io.iohk.atala.prism.protos.node_models
+import io.iohk.atala.prism.protos.node_models.SignedAtalaOperation
 import tofu.logging.derivation.loggable
 
 package object models {
@@ -69,4 +67,5 @@ package object models {
     }
 
   type AtalaObjectNotificationHandler[F[_]] = AtalaObjectNotification => F[Unit]
+  type AtalaObjectBulkNotificationHandler[F[_]] = List[AtalaObjectNotification] => F[Unit]
 }

--- a/src/test/scala/io/iohk/atala/prism/node/services/CardanoLedgerServiceIntegrationSpec.scala
+++ b/src/test/scala/io/iohk/atala/prism/node/services/CardanoLedgerServiceIntegrationSpec.scala
@@ -71,7 +71,8 @@ class CardanoLedgerServiceIntegrationSpec extends AtalaWithPostgresSpec {
         cardanoClient,
         keyValueService,
         notificationHandler.asCardanoBlockHandler,
-        notificationHandler.asAtalaObjectHandler
+        notificationHandler.asAtalaObjectHandler,
+        notificationHandler.asAtalaObjectBulkHandler
       )
 
       // Avoid syncing pre-existing blocks

--- a/src/test/scala/io/iohk/atala/prism/node/services/models/testing/TestAtalaHandlers.scala
+++ b/src/test/scala/io/iohk/atala/prism/node/services/models/testing/TestAtalaHandlers.scala
@@ -3,12 +3,13 @@ package io.iohk.atala.prism.node.services.models.testing
 import cats.Applicative
 import io.iohk.atala.prism.node.cardano.models.Block.Canonical
 import io.iohk.atala.prism.node.services.models.AtalaObjectNotification
-
 import scala.collection.mutable
 
 class TestAtalaHandlers[F[_]: Applicative] {
 
   val receivedNotifications: mutable.Buffer[AtalaObjectNotification] =
+    mutable.ArrayBuffer()
+  val receivedAtalaObjectBulk: mutable.Buffer[List[AtalaObjectNotification]] =
     mutable.ArrayBuffer()
 
   def asAtalaObjectHandler(
@@ -22,6 +23,11 @@ class TestAtalaHandlers[F[_]: Applicative] {
 
   def asCardanoBlockHandler(block: Canonical): F[Unit] = {
     receivedCardanoBlocks += block
+    Applicative[F].unit
+  }
+
+  def asAtalaObjectBulkHandler(notifications: List[AtalaObjectNotification]): F[Unit] = {
+    receivedAtalaObjectBulk += notifications
     Applicative[F].unit
   }
 }


### PR DESCRIPTION

## Overview
This PR introduces bulk synchronization of the node state from the Cardano db-sync.
Bulk sync is a one-time, high-efficiency catch-up process that processes all Atala objects from the starting block(as defined in config `blockNumberSyncStart` ) in large batches of `5000` and stops at  `lastConfirmedBlockNo -blockConfirmationsToWait`, after which it updates the sync pointer so that regular incremental syncing can resume.


## Screenshots
<!-- In case the PR involves UI changes, make sure to include success/failure related screenshots -->

## Checklists
<!-- Details you need to consider that are commonly forgotten -->

Pre-submit checklist:
- [ ] Self-reviewed the diff
- [ ] New code has proper comments/documentation/tests
- [ ] Any changes not covered by tests have been tested manually
- [ ] The README files are updated
- [ ] If new libraries are included, they have licenses compatible with our project
- [ ] If there is a db migration altering existing tables, there is a proper migration test

Pre-merge checklist:
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
