### PR TITLE
fix: configurable cardano sync delay

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -41,6 +41,10 @@ refreshAndSubmitPeriod = ${?NODE_REFRESH_AND_SUBMIT_PERIOD}
 moveScheduledToPendingPeriod = "15s"
 moveScheduledToPendingPeriod = ${?NODE_MOVE_SCHEDULED_TO_PENDING_PERIOD}
 
+# Time period to schedule the next polling if prism block is not found
+scheduleSyncPeriod = "20s"
+scheduleSyncPeriod = ${?NODE_SCHEDULE_SYNC_PERIOD}
+
 # Maximum number of transactions cardano-wallet can work with
 transactionsPerSecond = 10
 transactionsPerSecond = ${?NODE_WALLET_MAX_TPS}

--- a/src/main/scala/io/iohk/atala/prism/node/services/CardanoLedgerService.scala
+++ b/src/main/scala/io/iohk/atala/prism/node/services/CardanoLedgerService.scala
@@ -57,6 +57,8 @@ import scala.concurrent.duration._
   *   callback on every new confirmed Cardano block.
   * @param onAtalaObject
   *   callback on every AtalaObject found in confirmed transactions.
+  * @param scheduleSyncPeriod
+  *   delay which the ledger will be polled if no blocks are found.
   */
 class CardanoLedgerService[F[_]] private[services] (
     network: CardanoNetwork,
@@ -70,7 +72,8 @@ class CardanoLedgerService[F[_]] private[services] (
     keyValueService: KeyValueService[F],
     onCardanoBlock: CardanoBlockHandler[F],
     onAtalaObject: AtalaObjectNotificationHandler[F],
-    onAtalaObjectBulk: AtalaObjectBulkNotificationHandler[F]
+    onAtalaObjectBulk: AtalaObjectBulkNotificationHandler[F],
+    scheduleSyncPeriod: FiniteDuration
 )(implicit
     timer: Temporal[F],
     liftToFuture: Lift[F, Future]
@@ -148,7 +151,7 @@ class CardanoLedgerService[F[_]] private[services] (
               // There blocks to sync, don't wait to sync faster
               scheduleSync(0.seconds)
             } else {
-              scheduleSync(20.seconds)
+              scheduleSync(scheduleSyncPeriod)
             }
           }
     )
@@ -379,6 +382,7 @@ object CardanoLedgerService {
       onCardanoBlock: CardanoBlockHandler[F],
       onAtalaObject: AtalaObjectNotificationHandler[F],
       onAtalaObjectBulk: AtalaObjectBulkNotificationHandler[F],
+      scheduleSyncPeriod: FiniteDuration,
       logs: Logs[R, F]
   ): R[UnderlyingLedger[F]] =
     for {
@@ -400,7 +404,8 @@ object CardanoLedgerService {
         keyValueService,
         onCardanoBlock,
         onAtalaObject,
-        onAtalaObjectBulk
+        onAtalaObjectBulk,
+        scheduleSyncPeriod
       )
     }
 
@@ -411,6 +416,7 @@ object CardanoLedgerService {
       onCardanoBlock: CardanoBlockHandler[F],
       onAtalaObject: AtalaObjectNotificationHandler[F],
       onAtalaObjectBulk: AtalaObjectBulkNotificationHandler[F],
+      scheduleSyncPeriod: FiniteDuration,
       logs: Logs[R, F]
   ): Resource[R, UnderlyingLedger[F]] = {
     val walletId = WalletId
@@ -437,6 +443,7 @@ object CardanoLedgerService {
         onCardanoBlock,
         onAtalaObject,
         onAtalaObjectBulk,
+        scheduleSyncPeriod,
         logs
       )
     )
@@ -449,6 +456,7 @@ object CardanoLedgerService {
       onCardanoBlock: CardanoBlockHandler[F],
       onAtalaObject: AtalaObjectNotificationHandler[F],
       onAtalaObjectBulk: AtalaObjectBulkNotificationHandler[F],
+      scheduleSyncPeriod: FiniteDuration,
       logs: Logs[R, F]
   ): UnderlyingLedger[F] = {
     val walletId = WalletId
@@ -474,6 +482,7 @@ object CardanoLedgerService {
       onCardanoBlock,
       onAtalaObject,
       onAtalaObjectBulk,
+      scheduleSyncPeriod,
       logs
     ).extract
   }

--- a/src/test/scala/io/iohk/atala/prism/node/services/CardanoLedgerServiceIntegrationSpec.scala
+++ b/src/test/scala/io/iohk/atala/prism/node/services/CardanoLedgerServiceIntegrationSpec.scala
@@ -32,6 +32,7 @@ class CardanoLedgerServiceIntegrationSpec extends AtalaWithPostgresSpec {
   private val LONG_TIMEOUT = Timeout(1.minute)
   private val RETRY_TIMEOUT = 2.minutes
   private val RETRY_SLEEP = 10.seconds
+  private val SCHEDULE_SYNC_PERIOD = 1.seconds
   private val initialBulkSyncSize = 5000
   "CardanoLedgerService" should {
     "notify on published PRISM transactions" in {
@@ -73,7 +74,8 @@ class CardanoLedgerServiceIntegrationSpec extends AtalaWithPostgresSpec {
         keyValueService,
         notificationHandler.asCardanoBlockHandler,
         notificationHandler.asAtalaObjectHandler,
-        notificationHandler.asAtalaObjectBulkHandler
+        notificationHandler.asAtalaObjectBulkHandler,
+        SCHEDULE_SYNC_PERIOD
       )
 
       // Avoid syncing pre-existing blocks

--- a/src/test/scala/io/iohk/atala/prism/node/services/CardanoLedgerServiceSpec.scala
+++ b/src/test/scala/io/iohk/atala/prism/node/services/CardanoLedgerServiceSpec.scala
@@ -28,6 +28,7 @@ import io.iohk.atala.prism.node.utils.IOUtils._
 import io.iohk.atala.prism.protos.node_models
 import org.scalatest.OptionValues._
 import tofu.logging.Logs
+import scala.concurrent.duration._
 class CardanoLedgerServiceSpec extends AtalaWithPostgresSpec {
   private val logs = Logs.withContext[IO, IOWithTraceIdContext]
   private val network = CardanoNetwork.Testnet
@@ -49,6 +50,7 @@ class CardanoLedgerServiceSpec extends AtalaWithPostgresSpec {
   )
   private lazy val cardanoBlockRepository =
     CardanoBlockRepository.unsafe(dbLiftedToTraceIdIO, logs)
+  private val scheduleSyncPeriod = 1.seconds
 
   override def beforeAll(): Unit = {
     super.beforeAll()
@@ -424,7 +426,8 @@ class CardanoLedgerServiceSpec extends AtalaWithPostgresSpec {
       keyValueService,
       noOpBlockHandler,
       onAtalaObject,
-      onAtalaObjectBulk
+      onAtalaObjectBulk,
+      scheduleSyncPeriod
     )
   }
 


### PR DESCRIPTION
## Overview
We have an integration test with local cardano testnet to check PRISM specification. The default cardano sync delay is 20 seconds which is too long run in CI. This PR exposes the configuraion to variable `NODE_SCHEDULE_SYNC_DELAY` which by default is still 20 seconds, but on CI, we'll be setting much lower value to improve CI time. 

## Checklists

Pre-submit checklist:
- [x] Self-reviewed the diff
- [ ] New code has proper comments/documentation/tests
- [x] Any changes not covered by tests have been tested manually
- [ ] The README files are updated
- [ ] If new libraries are included, they have licenses compatible with our project
- [ ] If there is a db migration altering existing tables, there is a proper migration test

Pre-merge checklist:
- [x] Commits have useful messages
- [x] Review clarifications made it into the code
