### PR TITLE
feat: add VDR driver implementation, documentation and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,18 @@ export NODE_LEDGER="cardano"
 
 For more configuration options, please refer to `node/src/main/resources/application.conf`. Note that environment values override the configuration values. You can change locally the `application.conf` instead of exporting environment variables as we did above.
 
+### VDR entry retrieval: latest vs historical
+
+The VDR API now distinguishes between fetching a specific historical event and the latest state of a storage entry:
+
+- `GetVdrEntryRequest` fields:
+  - `event_hash` – when `latest` is false (default), returns that exact historical event.
+  - `entry_id` – logical identifier of the VDR entry (returned in create/update/deactivate outputs).
+  - `latest` – when true, returns the newest event for the given `entry_id` (or uses `event_hash` as the id if `entry_id` is omitted).
+- A head table (`vdr_entry_heads`) maintains the newest hash per `entry_id`; if absent, the chain is walked and the head is cached.
+
+Use `entry_id` with `latest=true` to read the current value of mutable data. Use `event_hash` with `latest=false` for audit/history.
+
 ## Working with the codebase
 
 In order to keep the code format consistent, we use scalafmt and git hooks, follow these steps to configure it accordingly (otherwise, your changes are going to be rejected by CircleCI):
@@ -194,4 +206,3 @@ If you encounter an error while importing the build, run "Metals: switch build s
 run "Metals: run doctor" to see if all sub-project builds have been imported
 
 run "Metals: restart build server" to restart the build server, if editor is acting weird.
-

--- a/atala-prism/src/test/scala/io/iohk/atala/prism/node/repositories/VdrEntriesRepositorySpec.scala
+++ b/atala-prism/src/test/scala/io/iohk/atala/prism/node/repositories/VdrEntriesRepositorySpec.scala
@@ -1,0 +1,56 @@
+package io.iohk.atala.prism.node.repositories
+
+import cats.effect.unsafe.implicits.global
+import doobie.implicits._
+import io.iohk.atala.prism.node.{AtalaWithPostgresSpec, DataPreparation}
+import io.iohk.atala.prism.node.crypto.CryptoTestUtils
+import io.iohk.atala.prism.node.crypto.CryptoUtils.Sha256Hash
+import io.iohk.atala.prism.node.models.StorageData.Bytes
+import io.iohk.atala.prism.node.models._
+import io.iohk.atala.prism.node.repositories.daos.{DIDDataDAO, PublicKeysDAO, VdrEntriesDAO}
+import org.scalatest.OptionValues._
+
+/** Lightweight repository-level check that heads are updated on create/update/deactivate. */
+class VdrEntriesRepositorySpec extends AtalaWithPostgresSpec {
+
+  private val didHash = Sha256Hash.compute("repo-did".getBytes())
+  private val didSuffix = DidSuffix(didHash.hexEncoded)
+  private val vdrKey = CryptoTestUtils.generateKeyPair()
+  private val ledgerData = DataPreparation.dummyLedgerData
+
+  private lazy val repo = new VdrEntriesRepositoryImpl(database)
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    DIDDataDAO.insert(didSuffix, didHash, ledgerData).transact(database).unsafeRunSync()
+    PublicKeysDAO
+      .insert(
+        DIDPublicKey(didSuffix, "vdr", KeyUsage.VDRKey, CryptoTestUtils.toPublicKeyData(vdrKey.publicKey)),
+        ledgerData
+      )
+      .transact(database)
+      .unsafeRunSync()
+  }
+
+  "VdrEntriesRepository" should {
+    "update head to DEACTIVATED on deactivate" in {
+      val createHash = Sha256Hash.compute("repo-create".getBytes)
+      val updateHash = Sha256Hash.compute("repo-update".getBytes)
+      val deactivateHash = Sha256Hash.compute("repo-deactivate".getBytes)
+
+      repo
+        .insertCreate(createHash, didSuffix, None, Bytes("v1".getBytes.toVector), ledgerData)
+        .unsafeRunSync()
+      repo
+        .insertUpdate(updateHash, didSuffix, createHash, Bytes("v2".getBytes.toVector), ledgerData)
+        .unsafeRunSync()
+      repo
+        .insertDeactivate(deactivateHash, didSuffix, updateHash, ledgerData)
+        .unsafeRunSync()
+
+      val head = VdrEntriesDAO.findHead(createHash).transact(database).unsafeRunSync().value
+      head._1 mustBe deactivateHash
+      head._2 mustBe VdrEntryStatus.DEACTIVATED
+    }
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -45,7 +45,7 @@ lazy val versions = new {
   val typesafeConfig = "1.4.2"
   val fs2 = "3.8.0"
   val scalaUri = "4.0.0"
-  val testContainers = "0.41.4"
+  val testContainers = "0.44.1"
 }
 
 lazy val Dependencies = new {

--- a/docs/cardano/cardano-in-atala-prism.md
+++ b/docs/cardano/cardano-in-atala-prism.md
@@ -113,5 +113,6 @@ Atala Prism integrates with:
 - The node implements the Cardano PRISM VDR driver spec (<https://github.com/hyperledger-identus/prism-vdr-driver/blob/main/prism-vdr-specification.md>) with dedicated storage operations: create/update/deactivate VDR entry, plus get/verify endpoints.
 - VDR entries carry opaque `StorageData` (raw bytes or IPFS CID) and are chained by `previous_event_hash`; deactivation is expressed as a new event with status `DEACTIVATED`.
 - VDR operations must be signed with an active `VDR_KEY` (secp256k1 only) on the target DID; the key is optional and does not replace the master key.
+- `getVdrEntryLatest` follows the head of the chain and returns `FAILED_PRECONDITION (vdr-entry-deactivated)` when the newest event is `DEACTIVATED`; callers should treat this as a hard error rather than falling back to older events. Missing entries still surface as `UNKNOWN (unknown-value)`.
 - Nodes without the storage feature can ignore these operations at the API layer; ledger batching reuses the standard AtalaOperation flow.
 .

--- a/src/main/protobuf/node_api.proto
+++ b/src/main/protobuf/node_api.proto
@@ -236,6 +236,8 @@ message DeactivateVdrEntryResponse {
 
 message GetVdrEntryRequest {
     bytes event_hash = 1;
+    bytes entry_id = 2;
+    bool latest = 3;
 }
 
 message VdrEntry {
@@ -290,10 +292,13 @@ message ProtocolVersionUpdateOutput {}
 message DeactivateDIDOutput {}
 message CreateVdrEntryOutput {
     bytes event_hash = 1;
+    bytes entry_id = 2;
 }
 message UpdateVdrEntryOutput {
     bytes event_hash = 1;
+    bytes entry_id = 2;
 }
 message DeactivateVdrEntryOutput {
     bytes event_hash = 1;
+    bytes entry_id = 2;
 }

--- a/src/main/protobuf/node_api.proto
+++ b/src/main/protobuf/node_api.proto
@@ -247,10 +247,17 @@ message VdrEntry {
     bytes previous_event_hash = 4;
     bool deactivated = 5;
     bytes nonce = 6;
+    VdrEntryStatus status = 7;
 }
 
 message GetVdrEntryResponse {
     VdrEntry entry = 1;
+}
+
+enum VdrEntryStatus {
+    ACTIVE = 0;
+    DEACTIVATED = 1;
+    UNKNOWN_STATUS = 2;
 }
 
 message VerifyVdrEntryRequest {

--- a/src/main/resources/db/migration/V3__vdr_storage.sql
+++ b/src/main/resources/db/migration/V3__vdr_storage.sql
@@ -1,4 +1,3 @@
--- VDR storage entries
 CREATE TYPE public.vdr_entry_status AS ENUM ('ACTIVE', 'DEACTIVATED');
 
 CREATE TABLE public.vdr_entries
@@ -24,7 +23,6 @@ CREATE TABLE public.vdr_entries
 CREATE INDEX vdr_entries_did_suffix_idx ON public.vdr_entries USING btree (did_suffix);
 CREATE INDEX vdr_entries_entry_id_idx ON public.vdr_entries USING btree (entry_id);
 CREATE INDEX vdr_entries_prev_event_idx ON public.vdr_entries USING btree (previous_event_hash);
-CREATE INDEX vdr_entry_heads_status_idx ON public.vdr_entry_heads USING btree (status, entry_id);
 
 -- Head pointers for VDR storage entry chains
 CREATE TABLE public.vdr_entry_heads
@@ -36,3 +34,4 @@ CREATE TABLE public.vdr_entry_heads
 );
 
 CREATE INDEX vdr_entry_heads_latest_idx ON public.vdr_entry_heads USING btree (latest_hash);
+CREATE INDEX vdr_entry_heads_status_idx ON public.vdr_entry_heads USING btree (status, entry_id);

--- a/src/main/resources/db/migration/V3__vdr_storage.sql
+++ b/src/main/resources/db/migration/V3__vdr_storage.sql
@@ -3,6 +3,7 @@ CREATE TYPE public.vdr_entry_status AS ENUM ('ACTIVE', 'DEACTIVATED');
 
 CREATE TABLE public.vdr_entries
 (
+    entry_id            public.operation_hash        NOT NULL,
     event_hash           public.operation_hash        NOT NULL,
     did_suffix           public.id_type               NOT NULL,
     nonce                BYTEA                        NULL,
@@ -21,7 +22,9 @@ CREATE TABLE public.vdr_entries
 );
 
 CREATE INDEX vdr_entries_did_suffix_idx ON public.vdr_entries USING btree (did_suffix);
+CREATE INDEX vdr_entries_entry_id_idx ON public.vdr_entries USING btree (entry_id);
 CREATE INDEX vdr_entries_prev_event_idx ON public.vdr_entries USING btree (previous_event_hash);
+CREATE INDEX vdr_entry_heads_status_idx ON public.vdr_entry_heads USING btree (status, entry_id);
 
 -- Head pointers for VDR storage entry chains
 CREATE TABLE public.vdr_entry_heads

--- a/src/main/resources/db/migration/V3__vdr_storage.sql
+++ b/src/main/resources/db/migration/V3__vdr_storage.sql
@@ -22,3 +22,14 @@ CREATE TABLE public.vdr_entries
 
 CREATE INDEX vdr_entries_did_suffix_idx ON public.vdr_entries USING btree (did_suffix);
 CREATE INDEX vdr_entries_prev_event_idx ON public.vdr_entries USING btree (previous_event_hash);
+
+-- Head pointers for VDR storage entry chains
+CREATE TABLE public.vdr_entry_heads
+(
+    entry_id     public.operation_hash PRIMARY KEY, -- hash of the create event (root of the chain)
+    latest_hash  public.operation_hash NOT NULL,    -- hash of the latest event in the chain
+    status       public.vdr_entry_status NOT NULL DEFAULT 'ACTIVE',
+    updated_at   timestamptz NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX vdr_entry_heads_latest_idx ON public.vdr_entry_heads USING btree (latest_hash);

--- a/src/main/scala/io/iohk/atala/prism/node/NodeGrpcServiceImpl.scala
+++ b/src/main/scala/io/iohk/atala/prism/node/NodeGrpcServiceImpl.scala
@@ -257,8 +257,13 @@ class NodeGrpcServiceImpl(
     val methodName = "getVdrEntry"
     measureRequestFuture(serviceName, methodName) {
       trace { traceId =>
-        nodeService
-          .getVdrEntry(request.eventHash)
+        val latestRequested = request.latest || !request.entryId.isEmpty
+        val effect =
+          if (latestRequested)
+            nodeService.getVdrEntryLatest(if (!request.entryId.isEmpty) request.entryId else request.eventHash)
+          else nodeService.getVdrEntry(request.eventHash)
+
+        effect
           .map(
             _.fold(
               err => countAndThrowNodeError(methodName, err),

--- a/src/main/scala/io/iohk/atala/prism/node/operations/StorageOperations.scala
+++ b/src/main/scala/io/iohk/atala/prism/node/operations/StorageOperations.scala
@@ -20,33 +20,28 @@ import io.iohk.atala.prism.node.operations.ValidationError.InvalidValue
 import io.iohk.atala.prism.node.operations.path._
 import io.iohk.atala.prism.node.repositories.daos.{DIDDataDAO, PublicKeysDAO, VdrEntriesDAO}
 import io.iohk.atala.prism.protos.node_models
-import io.iohk.atala.prism.node.models.nodeState.DIDPublicKeyState
-
 import scala.util.Try
 
 sealed trait StorageOperation extends Operation {
-  protected def vdrKeyForDid(didSuffix: DidSuffix, keyId: String): EitherT[ConnectionIO, StateError, SecpPublicKey] = {
-    val normalize: Either[StateError, String] = {
-      val (maybeDidSuffix, kid) =
-        if (keyId.contains("#")) {
-          val Array(didPart, kidPart) = keyId.split("#", 2)
-          (DidSuffix.fromString(didPart.split(":").lastOption.getOrElse("")).toOption, kidPart)
-        } else (None, keyId)
-
-      maybeDidSuffix match {
-        case Some(ds) if ds != didSuffix =>
-          Left(EntityMissing("key", keyId): StateError)
-        case _ =>
-          Right(kid)
-      }
-    }
-
-    def toSecp(state: DIDPublicKeyState): Either[StateError, SecpPublicKey] =
-      Try(SecpPublicKey.unsafeFromCompressed(state.key.compressedKey)).toEither
-        .leftMap(_ => IllegalSecp256k1Key(state.keyId): StateError)
-
+  protected def vdrKeyForDid(didSuffix: DidSuffix, keyId: String): EitherT[ConnectionIO, StateError, SecpPublicKey] =
     for {
-      normalizedKeyId <- EitherT.fromEither[ConnectionIO](normalize)
+      normalizedKeyId <- EitherT.fromEither[ConnectionIO] {
+        if (!keyId.contains("#")) {
+          // backward compatibility: treat bare key ids as belonging to the DID of the current operation
+          Right(keyId)
+        } else {
+          val Array(didPart, kidPart) = keyId.split("#", 2)
+          val maybeSuffix =
+            // prefer the suffix part of a fully qualified DID (did:prism:<suffix>)
+            if (didPart.startsWith("did:")) DidSuffix.fromString(didPart.split(":").last).toOption
+            else DidSuffix.fromString(didPart).toOption
+
+          maybeSuffix match {
+            case Some(ds) if ds == didSuffix => Right(kidPart)
+            case _ => Left(EntityMissing("key", keyId): StateError)
+          }
+        }
+      }
       secpKey <- EitherT[ConnectionIO, StateError, SecpPublicKey] {
         PublicKeysDAO
           .find(didSuffix, normalizedKeyId)
@@ -55,12 +50,12 @@ sealed trait StorageOperation extends Operation {
             for {
               _ <- Either.cond(state.keyUsage == KeyUsage.VDRKey, (), InvalidKeyUsed("VDR signing key"))
               _ <- Either.cond(state.revokedOn.isEmpty, (), StateError.KeyAlreadyRevoked(): StateError)
-              secp <- toSecp(state)
+              secp <- Try(SecpPublicKey.unsafeFromCompressed(state.key.compressedKey)).toEither
+                .leftMap(_ => IllegalSecp256k1Key(state.keyId): StateError)
             } yield secp
           })
       }
     } yield secpKey
-  }
 
   protected def ensureDidExists(didSuffix: DidSuffix): EitherT[ConnectionIO, StateError, Unit] =
     EitherT {
@@ -71,6 +66,34 @@ sealed trait StorageOperation extends Operation {
           case None => Left(EntityMissing("did suffix", didSuffix.getValue): StateError)
         }
     }
+
+  /** Fetch the current head for the chain identified by `previousEventHash`, ensuring it is ACTIVE and matches the
+    * provided hash.
+    */
+  protected def resolveActiveHead(
+      previousEventHash: Sha256Hash
+  ): EitherT[ConnectionIO, StateError, (Sha256Hash, VdrEntriesDAO.VdrEntryRow)] =
+    for {
+      entryId <- EitherT.fromOptionF(
+        VdrEntriesDAO.findRootOf(previousEventHash).map(_.orElse(Some(previousEventHash))),
+        EntityMissing("vdr entry", previousEventHash.hexEncoded): StateError
+      )
+      head <- EitherT.fromOptionF(
+        VdrEntriesDAO
+          .findHead(entryId)
+          .flatMap {
+            case Some((h, _)) => VdrEntriesDAO.find(h)
+            case None => VdrEntriesDAO.findLatestFrom(entryId)
+          },
+        EntityMissing("vdr entry", previousEventHash.hexEncoded): StateError
+      )
+      _ <- EitherT.fromEither[ConnectionIO](
+        Either.cond(head.status == VdrEntryStatus.ACTIVE, (), InvalidPreviousOperation(): StateError)
+      )
+      _ <- EitherT.fromEither[ConnectionIO](
+        Either.cond(head.eventHash == previousEventHash, (), InvalidPreviousOperation(): StateError)
+      )
+    } yield (entryId, head)
 }
 
 final case class CreateStorageEntryOperation(
@@ -93,23 +116,28 @@ final case class CreateStorageEntryOperation(
       case Bytes(value) => ("BYTES", Some(value.toArray), None)
       case IpfsCid(cid) => ("IPFS", None, Some(cid))
     }
-    EitherT {
-      VdrEntriesDAO
-        .insert(
-          digest,
-          didSuffix,
-          nonce.map(_.toArray),
-          dataType,
-          dataBytes,
-          dataIpfs,
-          None,
-          VdrEntryStatus.ACTIVE,
-          ledgerData
-        )
-        .attemptSomeSqlState { case sqlstate.class23.UNIQUE_VIOLATION =>
-          EntityExists("vdr entry", digest.hexEncoded): StateError
-        }
-    }
+    for {
+      _ <- EitherT {
+        VdrEntriesDAO
+          .insert(
+            digest,
+            didSuffix,
+            nonce.map(_.toArray),
+            dataType,
+            dataBytes,
+            dataIpfs,
+            None,
+            VdrEntryStatus.ACTIVE,
+            ledgerData
+          )
+          .attemptSomeSqlState { case sqlstate.class23.UNIQUE_VIOLATION =>
+            EntityExists("vdr entry", digest.hexEncoded): StateError
+          }
+      }
+      _ <- EitherT.right(
+        VdrEntriesDAO.insertHead(digest, digest, VdrEntryStatus.ACTIVE).attemptSql
+      )
+    } yield ()
   }
 }
 
@@ -125,15 +153,9 @@ final case class UpdateStorageEntryOperation(
 
   override def getCorrectnessData(keyId: String): EitherT[ConnectionIO, StateError, CorrectnessData] =
     for {
-      prev <- EitherT[ConnectionIO, StateError, VdrEntriesDAO.VdrEntryRow] {
-        VdrEntriesDAO
-          .find(previousEventHash)
-          .map(_.toRight(EntityMissing("vdr entry", previousEventHash.hexEncoded): StateError))
-      }.subflatMap { row =>
-        Either.cond(row.status == VdrEntryStatus.ACTIVE, row, InvalidPreviousOperation(): StateError)
-      }
-      _ <- ensureDidExists(prev.didSuffix)
-      key <- vdrKeyForDid(prev.didSuffix, keyId)
+      head <- resolveActiveHead(previousEventHash).map(_._2)
+      _ <- ensureDidExists(head.didSuffix)
+      key <- vdrKeyForDid(head.didSuffix, keyId)
     } yield CorrectnessData(key, Some(previousEventHash))
 
   override protected def applyStateImpl(c: ApplyOperationConfig): EitherT[ConnectionIO, StateError, Unit] = {
@@ -142,18 +164,13 @@ final case class UpdateStorageEntryOperation(
       case IpfsCid(cid) => ("IPFS", None, Some(cid))
     }
     for {
-      prev <- EitherT.fromOptionF(
-        VdrEntriesDAO.find(previousEventHash),
-        EntityMissing("vdr entry", previousEventHash.hexEncoded): StateError
-      )
-      _ <- EitherT.fromEither[ConnectionIO](
-        Either.cond(prev.status == VdrEntryStatus.ACTIVE, (), InvalidPreviousOperation(): StateError)
-      )
+      resolved <- resolveActiveHead(previousEventHash)
+      (entryId, head) = resolved
       _ <- EitherT(
         VdrEntriesDAO
           .insert(
             digest,
-            prev.didSuffix,
+            head.didSuffix,
             None,
             dataType,
             dataBytes,
@@ -165,6 +182,12 @@ final case class UpdateStorageEntryOperation(
           .attemptSomeSqlState { case sqlstate.class23.UNIQUE_VIOLATION =>
             EntityExists("vdr entry", digest.hexEncoded): StateError
           }
+      )
+      entryId <- EitherT.right[StateError](
+        VdrEntriesDAO.findRootOf(previousEventHash).map(_.getOrElse(previousEventHash))
+      )
+      _ <- EitherT.right(
+        VdrEntriesDAO.updateHead(entryId, digest, VdrEntryStatus.ACTIVE).attemptSql
       )
     } yield ()
   }
@@ -181,31 +204,21 @@ final case class DeactivateStorageEntryOperation(
 
   override def getCorrectnessData(keyId: String): EitherT[ConnectionIO, StateError, CorrectnessData] =
     for {
-      prev <- EitherT[ConnectionIO, StateError, VdrEntriesDAO.VdrEntryRow] {
-        VdrEntriesDAO
-          .find(previousEventHash)
-          .map(_.toRight(EntityMissing("vdr entry", previousEventHash.hexEncoded): StateError))
-      }.subflatMap { row =>
-        Either.cond(row.status == VdrEntryStatus.ACTIVE, row, InvalidPreviousOperation(): StateError)
-      }
-      _ <- ensureDidExists(prev.didSuffix)
-      key <- vdrKeyForDid(prev.didSuffix, keyId)
+      resolved <- resolveActiveHead(previousEventHash)
+      (_, head) = resolved
+      _ <- ensureDidExists(head.didSuffix)
+      key <- vdrKeyForDid(head.didSuffix, keyId)
     } yield CorrectnessData(key, Some(previousEventHash))
 
   override protected def applyStateImpl(c: ApplyOperationConfig): EitherT[ConnectionIO, StateError, Unit] =
     for {
-      prev <- EitherT.fromOptionF(
-        VdrEntriesDAO.find(previousEventHash),
-        EntityMissing("vdr entry", previousEventHash.hexEncoded): StateError
-      )
-      _ <- EitherT.fromEither[ConnectionIO](
-        Either.cond(prev.status == VdrEntryStatus.ACTIVE, (), InvalidPreviousOperation(): StateError)
-      )
+      resolved <- resolveActiveHead(previousEventHash)
+      (entryId, head) = resolved
       _ <- EitherT(
         VdrEntriesDAO
           .insert(
             digest,
-            prev.didSuffix,
+            head.didSuffix,
             None,
             dataType = "NONE",
             dataBytes = None,
@@ -217,6 +230,12 @@ final case class DeactivateStorageEntryOperation(
           .attemptSomeSqlState { case sqlstate.class23.UNIQUE_VIOLATION =>
             EntityExists("vdr entry", digest.hexEncoded): StateError
           }
+      )
+      entryId <- EitherT.right[StateError](
+        VdrEntriesDAO.findRootOf(previousEventHash).map(_.getOrElse(previousEventHash))
+      )
+      _ <- EitherT.right(
+        VdrEntriesDAO.updateHead(entryId, digest, VdrEntryStatus.DEACTIVATED).attemptSql
       )
     } yield ()
 }

--- a/src/main/scala/io/iohk/atala/prism/node/operations/StorageOperations.scala
+++ b/src/main/scala/io/iohk/atala/prism/node/operations/StorageOperations.scala
@@ -25,23 +25,42 @@ import io.iohk.atala.prism.node.models.nodeState.DIDPublicKeyState
 import scala.util.Try
 
 sealed trait StorageOperation extends Operation {
-  protected def vdrKeyForDid(didSuffix: DidSuffix, keyId: String): EitherT[ConnectionIO, StateError, SecpPublicKey] =
-    for {
-      keyState <- EitherT[ConnectionIO, StateError, DIDPublicKeyState] {
-        PublicKeysDAO
-          .find(didSuffix, keyId)
-          .map(_.toRight(EntityMissing("key", keyId): StateError))
-      }.subflatMap { state =>
-        Either.cond(state.keyUsage == KeyUsage.VDRKey, state, InvalidKeyUsed("VDR signing key"))
-      }.subflatMap { state =>
-        Either.cond(state.revokedOn.isEmpty, state.key, StateError.KeyAlreadyRevoked())
+  protected def vdrKeyForDid(didSuffix: DidSuffix, keyId: String): EitherT[ConnectionIO, StateError, SecpPublicKey] = {
+    val normalize: Either[StateError, String] = {
+      val (maybeDidSuffix, kid) =
+        if (keyId.contains("#")) {
+          val Array(didPart, kidPart) = keyId.split("#", 2)
+          (DidSuffix.fromString(didPart.split(":").lastOption.getOrElse("")).toOption, kidPart)
+        } else (None, keyId)
+
+      maybeDidSuffix match {
+        case Some(ds) if ds != didSuffix =>
+          Left(EntityMissing("key", keyId): StateError)
+        case _ =>
+          Right(kid)
       }
-      secpKey <- EitherT.fromEither[ConnectionIO] {
-        Try {
-          SecpPublicKey.unsafeFromCompressed(keyState.compressedKey)
-        }.toEither.leftMap(_ => IllegalSecp256k1Key(keyId): StateError)
+    }
+
+    def toSecp(state: DIDPublicKeyState): Either[StateError, SecpPublicKey] =
+      Try(SecpPublicKey.unsafeFromCompressed(state.key.compressedKey)).toEither
+        .leftMap(_ => IllegalSecp256k1Key(state.keyId): StateError)
+
+    for {
+      normalizedKeyId <- EitherT.fromEither[ConnectionIO](normalize)
+      secpKey <- EitherT[ConnectionIO, StateError, SecpPublicKey] {
+        PublicKeysDAO
+          .find(didSuffix, normalizedKeyId)
+          .map(_.toRight(EntityMissing("key", keyId): StateError))
+          .map(_.flatMap { state =>
+            for {
+              _ <- Either.cond(state.keyUsage == KeyUsage.VDRKey, (), InvalidKeyUsed("VDR signing key"))
+              _ <- Either.cond(state.revokedOn.isEmpty, (), StateError.KeyAlreadyRevoked(): StateError)
+              secp <- toSecp(state)
+            } yield secp
+          })
       }
     } yield secpKey
+  }
 
   protected def ensureDidExists(didSuffix: DidSuffix): EitherT[ConnectionIO, StateError, Unit] =
     EitherT {

--- a/src/main/scala/io/iohk/atala/prism/node/operations/StorageOperations.scala
+++ b/src/main/scala/io/iohk/atala/prism/node/operations/StorageOperations.scala
@@ -78,13 +78,12 @@ sealed trait StorageOperation extends Operation {
         VdrEntriesDAO.findRootOf(previousEventHash).map(_.orElse(Some(previousEventHash))),
         EntityMissing("vdr entry", previousEventHash.hexEncoded): StateError
       )
+      headHash <- EitherT.fromOptionF(
+        VdrEntriesDAO.findHead(entryId),
+        EntityMissing("vdr entry", previousEventHash.hexEncoded): StateError
+      )
       head <- EitherT.fromOptionF(
-        VdrEntriesDAO
-          .findHead(entryId)
-          .flatMap {
-            case Some((h, _)) => VdrEntriesDAO.find(h)
-            case None => VdrEntriesDAO.findLatestFrom(entryId)
-          },
+        VdrEntriesDAO.find(headHash._1),
         EntityMissing("vdr entry", previousEventHash.hexEncoded): StateError
       )
       _ <- EitherT.fromEither[ConnectionIO](
@@ -120,6 +119,7 @@ final case class CreateStorageEntryOperation(
       _ <- EitherT {
         VdrEntriesDAO
           .insert(
+            digest,
             digest,
             didSuffix,
             nonce.map(_.toArray),
@@ -169,6 +169,7 @@ final case class UpdateStorageEntryOperation(
       _ <- EitherT(
         VdrEntriesDAO
           .insert(
+            entryId,
             digest,
             head.didSuffix,
             None,
@@ -182,9 +183,6 @@ final case class UpdateStorageEntryOperation(
           .attemptSomeSqlState { case sqlstate.class23.UNIQUE_VIOLATION =>
             EntityExists("vdr entry", digest.hexEncoded): StateError
           }
-      )
-      entryId <- EitherT.right[StateError](
-        VdrEntriesDAO.findRootOf(previousEventHash).map(_.getOrElse(previousEventHash))
       )
       _ <- EitherT.right(
         VdrEntriesDAO.updateHead(entryId, digest, VdrEntryStatus.ACTIVE).attemptSql
@@ -217,6 +215,7 @@ final case class DeactivateStorageEntryOperation(
       _ <- EitherT(
         VdrEntriesDAO
           .insert(
+            entryId,
             digest,
             head.didSuffix,
             None,
@@ -230,9 +229,6 @@ final case class DeactivateStorageEntryOperation(
           .attemptSomeSqlState { case sqlstate.class23.UNIQUE_VIOLATION =>
             EntityExists("vdr entry", digest.hexEncoded): StateError
           }
-      )
-      entryId <- EitherT.right[StateError](
-        VdrEntriesDAO.findRootOf(previousEventHash).map(_.getOrElse(previousEventHash))
       )
       _ <- EitherT.right(
         VdrEntriesDAO.updateHead(entryId, digest, VdrEntryStatus.DEACTIVATED).attemptSql

--- a/src/main/scala/io/iohk/atala/prism/node/repositories/VdrEntriesRepository.scala
+++ b/src/main/scala/io/iohk/atala/prism/node/repositories/VdrEntriesRepository.scala
@@ -111,11 +111,12 @@ private final class VdrEntriesRepositoryImpl[F[_]: MonadCancelThrow](
       ledgerData: LedgerData
   ): F[Unit] = {
     val (dataType, dataBytes, dataIpfs) = toDbData(data)
-    VdrEntriesDAO
-      .insert(eventHash, didSuffix, nonce, dataType, dataBytes, dataIpfs, None, VdrEntryStatus.ACTIVE, ledgerData)
-      .logSQLErrorsV2("insert vdr create")
-      .transact(xa)
-      .flatTap(_ => VdrEntriesDAO.insertHead(eventHash, eventHash, VdrEntryStatus.ACTIVE).transact(xa))
+    (for {
+      _ <- VdrEntriesDAO
+        .insert(eventHash, didSuffix, nonce, dataType, dataBytes, dataIpfs, None, VdrEntryStatus.ACTIVE, ledgerData)
+        .logSQLErrorsV2("insert vdr create")
+      _ <- VdrEntriesDAO.insertHead(eventHash, eventHash, VdrEntryStatus.ACTIVE)
+    } yield ()).transact(xa)
   }
 
   override def insertUpdate(
@@ -178,13 +179,21 @@ private final class VdrEntriesRepositoryImpl[F[_]: MonadCancelThrow](
       .transact(xa)
 
   override def findLatest(eventHash: Sha256Hash): F[Option[VdrEntry]] =
-    VdrEntriesDAO
-      .findLatestFrom(eventHash)
-      .flatTap {
+    (for {
+      headOpt <- VdrEntriesDAO.findHead(eventHash)
+      recompute = VdrEntriesDAO.findLatestFrom(eventHash).flatTap {
         case Some(row) => VdrEntriesDAO.insertHead(eventHash, row.eventHash, row.status)
         case None => Applicative[doobie.free.connection.ConnectionIO].pure(())
       }
-      .map(_.flatMap(fromDb))
+      latestRowOpt <- headOpt match {
+        case Some((latestHash, _)) =>
+          VdrEntriesDAO.find(latestHash).flatMap {
+            case Some(row) => Applicative[doobie.free.connection.ConnectionIO].pure(Option(row))
+            case None => recompute // stale head, recompute and refresh
+          }
+        case None => recompute
+      }
+    } yield latestRowOpt.flatMap(fromDb))
       .logSQLErrorsV2(s"find latest vdr entry root=${eventHash.hexEncoded}")
       .transact(xa)
 }

--- a/src/main/scala/io/iohk/atala/prism/node/repositories/VdrEntriesRepository.scala
+++ b/src/main/scala/io/iohk/atala/prism/node/repositories/VdrEntriesRepository.scala
@@ -1,7 +1,6 @@
 package io.iohk.atala.prism.node.repositories
 
 import cats.Applicative
-import cats.syntax.flatMap._
 import cats.effect.MonadCancelThrow
 import cats.effect.Resource
 import doobie.implicits._
@@ -113,7 +112,18 @@ private final class VdrEntriesRepositoryImpl[F[_]: MonadCancelThrow](
     val (dataType, dataBytes, dataIpfs) = toDbData(data)
     (for {
       _ <- VdrEntriesDAO
-        .insert(eventHash, didSuffix, nonce, dataType, dataBytes, dataIpfs, None, VdrEntryStatus.ACTIVE, ledgerData)
+        .insert(
+          eventHash,
+          eventHash,
+          didSuffix,
+          nonce,
+          dataType,
+          dataBytes,
+          dataIpfs,
+          None,
+          VdrEntryStatus.ACTIVE,
+          ledgerData
+        )
         .logSQLErrorsV2("insert vdr create")
       _ <- VdrEntriesDAO.insertHead(eventHash, eventHash, VdrEntryStatus.ACTIVE)
     } yield ()).transact(xa)
@@ -132,6 +142,7 @@ private final class VdrEntriesRepositoryImpl[F[_]: MonadCancelThrow](
       entryId <- entryIdF
       _ <- VdrEntriesDAO
         .insert(
+          entryId,
           eventHash,
           didSuffix,
           None,
@@ -157,6 +168,7 @@ private final class VdrEntriesRepositoryImpl[F[_]: MonadCancelThrow](
       entryId <- VdrEntriesDAO.findRootOf(previousEventHash).map(_.getOrElse(previousEventHash))
       _ <- VdrEntriesDAO
         .insert(
+          entryId,
           eventHash,
           didSuffix,
           None,
@@ -179,21 +191,13 @@ private final class VdrEntriesRepositoryImpl[F[_]: MonadCancelThrow](
       .transact(xa)
 
   override def findLatest(eventHash: Sha256Hash): F[Option[VdrEntry]] =
-    (for {
-      headOpt <- VdrEntriesDAO.findHead(eventHash)
-      recompute = VdrEntriesDAO.findLatestFrom(eventHash).flatTap {
-        case Some(row) => VdrEntriesDAO.insertHead(eventHash, row.eventHash, row.status)
-        case None => Applicative[doobie.free.connection.ConnectionIO].pure(())
+    VdrEntriesDAO
+      .findHead(eventHash)
+      .flatMap {
+        case Some((latestHash, _)) => VdrEntriesDAO.find(latestHash)
+        case None => Applicative[doobie.free.connection.ConnectionIO].pure(Option.empty[VdrEntryRow])
       }
-      latestRowOpt <- headOpt match {
-        case Some((latestHash, _)) =>
-          VdrEntriesDAO.find(latestHash).flatMap {
-            case Some(row) => Applicative[doobie.free.connection.ConnectionIO].pure(Option(row))
-            case None => recompute // stale head, recompute and refresh
-          }
-        case None => recompute
-      }
-    } yield latestRowOpt.flatMap(fromDb))
+      .map(_.flatMap(fromDb))
       .logSQLErrorsV2(s"find latest vdr entry root=${eventHash.hexEncoded}")
       .transact(xa)
 }

--- a/src/main/scala/io/iohk/atala/prism/node/repositories/VdrEntriesRepository.scala
+++ b/src/main/scala/io/iohk/atala/prism/node/repositories/VdrEntriesRepository.scala
@@ -1,6 +1,7 @@
 package io.iohk.atala.prism.node.repositories
 
 import cats.Applicative
+import cats.syntax.flatMap._
 import cats.effect.MonadCancelThrow
 import cats.effect.Resource
 import doobie.implicits._
@@ -21,6 +22,12 @@ case class VdrEntry(
     previousEventHash: Option[Sha256Hash],
     status: VdrEntryStatus,
     nonce: Option[Array[Byte]]
+)
+
+final case class VdrEntryHead(
+    entryId: Sha256Hash,
+    latestHash: Sha256Hash,
+    status: VdrEntryStatus
 )
 
 trait VdrEntriesRepository[F[_]] {
@@ -48,6 +55,8 @@ trait VdrEntriesRepository[F[_]] {
   ): F[Unit]
 
   def find(eventHash: Sha256Hash): F[Option[VdrEntry]]
+
+  def findLatest(entryId: Sha256Hash): F[Option[VdrEntry]]
 }
 
 object VdrEntriesRepository {
@@ -106,6 +115,7 @@ private final class VdrEntriesRepositoryImpl[F[_]: MonadCancelThrow](
       .insert(eventHash, didSuffix, nonce, dataType, dataBytes, dataIpfs, None, VdrEntryStatus.ACTIVE, ledgerData)
       .logSQLErrorsV2("insert vdr create")
       .transact(xa)
+      .flatTap(_ => VdrEntriesDAO.insertHead(eventHash, eventHash, VdrEntryStatus.ACTIVE).transact(xa))
   }
 
   override def insertUpdate(
@@ -115,21 +125,25 @@ private final class VdrEntriesRepositoryImpl[F[_]: MonadCancelThrow](
       data: StorageData,
       ledgerData: LedgerData
   ): F[Unit] = {
+    val entryIdF = VdrEntriesDAO.findRootOf(previousEventHash).map(_.getOrElse(previousEventHash))
     val (dataType, dataBytes, dataIpfs) = toDbData(data)
-    VdrEntriesDAO
-      .insert(
-        eventHash,
-        didSuffix,
-        None,
-        dataType,
-        dataBytes,
-        dataIpfs,
-        Some(previousEventHash),
-        VdrEntryStatus.ACTIVE,
-        ledgerData
-      )
-      .logSQLErrorsV2("insert vdr update")
-      .transact(xa)
+    (for {
+      entryId <- entryIdF
+      _ <- VdrEntriesDAO
+        .insert(
+          eventHash,
+          didSuffix,
+          None,
+          dataType,
+          dataBytes,
+          dataIpfs,
+          Some(previousEventHash),
+          VdrEntryStatus.ACTIVE,
+          ledgerData
+        )
+        .logSQLErrorsV2("insert vdr update")
+      _ <- VdrEntriesDAO.updateHead(entryId, eventHash, VdrEntryStatus.ACTIVE)
+    } yield ()).transact(xa)
   }
 
   override def insertDeactivate(
@@ -138,25 +152,39 @@ private final class VdrEntriesRepositoryImpl[F[_]: MonadCancelThrow](
       previousEventHash: Sha256Hash,
       ledgerData: LedgerData
   ): F[Unit] =
-    VdrEntriesDAO
-      .insert(
-        eventHash,
-        didSuffix,
-        None,
-        dataType = "NONE",
-        dataBytes = None,
-        dataIpfs = None,
-        previousEventHash = Some(previousEventHash),
-        status = VdrEntryStatus.DEACTIVATED,
-        ledgerData = ledgerData
-      )
-      .logSQLErrorsV2("insert vdr deactivate")
-      .transact(xa)
+    (for {
+      entryId <- VdrEntriesDAO.findRootOf(previousEventHash).map(_.getOrElse(previousEventHash))
+      _ <- VdrEntriesDAO
+        .insert(
+          eventHash,
+          didSuffix,
+          None,
+          dataType = "NONE",
+          dataBytes = None,
+          dataIpfs = None,
+          previousEventHash = Some(previousEventHash),
+          status = VdrEntryStatus.DEACTIVATED,
+          ledgerData = ledgerData
+        )
+        .logSQLErrorsV2("insert vdr deactivate")
+      _ <- VdrEntriesDAO.updateHead(entryId, eventHash, VdrEntryStatus.DEACTIVATED)
+    } yield ()).transact(xa)
 
   override def find(eventHash: Sha256Hash): F[Option[VdrEntry]] =
     VdrEntriesDAO
       .find(eventHash)
       .map(_.flatMap(fromDb))
-      .logSQLErrorsV2("find vdr entry")
+      .logSQLErrorsV2(s"find vdr entry hash=${eventHash.hexEncoded}")
+      .transact(xa)
+
+  override def findLatest(eventHash: Sha256Hash): F[Option[VdrEntry]] =
+    VdrEntriesDAO
+      .findLatestFrom(eventHash)
+      .flatTap {
+        case Some(row) => VdrEntriesDAO.insertHead(eventHash, row.eventHash, row.status)
+        case None => Applicative[doobie.free.connection.ConnectionIO].pure(())
+      }
+      .map(_.flatMap(fromDb))
+      .logSQLErrorsV2(s"find latest vdr entry root=${eventHash.hexEncoded}")
       .transact(xa)
 }

--- a/src/main/scala/io/iohk/atala/prism/node/repositories/daos/VdrEntriesDAO.scala
+++ b/src/main/scala/io/iohk/atala/prism/node/repositories/daos/VdrEntriesDAO.scala
@@ -81,4 +81,60 @@ object VdrEntriesDAO {
           |FROM vdr_entries
           |WHERE event_hash = ${eventHash}
           |""".stripMargin.query[VdrEntryRow].option
+
+  def insertHead(entryId: Sha256Hash, latestHash: Sha256Hash, status: VdrEntryStatus): ConnectionIO[Unit] =
+    sql"""INSERT INTO vdr_entry_heads(entry_id, latest_hash, status)
+          |VALUES (${entryId}, ${latestHash}, ${status})
+          |ON CONFLICT (entry_id) DO UPDATE SET latest_hash = EXCLUDED.latest_hash, status = EXCLUDED.status, updated_at = NOW()
+          |""".stripMargin.update.run.void
+
+  def updateHead(entryId: Sha256Hash, latestHash: Sha256Hash, status: VdrEntryStatus): ConnectionIO[Unit] =
+    sql"""UPDATE vdr_entry_heads
+          |SET latest_hash = ${latestHash}, status = ${status}, updated_at = NOW()
+          |WHERE entry_id = ${entryId}
+          |""".stripMargin.update.run.void
+
+  def findHead(entryId: Sha256Hash): ConnectionIO[Option[(Sha256Hash, VdrEntryStatus)]] =
+    sql"""SELECT latest_hash, status FROM vdr_entry_heads WHERE entry_id = ${entryId}""".stripMargin
+      .query[(Sha256Hash, VdrEntryStatus)]
+      .option
+
+  /** Walk the chain from a given event hash forward and return the latest event (by created_at). */
+  def findLatestFrom(root: Sha256Hash): ConnectionIO[Option[VdrEntryRow]] =
+    sql"""
+      WITH RECURSIVE chain AS (
+        SELECT event_hash, did_suffix, nonce, data_type, data_bytes, data_ipfs, previous_event_hash, status,
+               created_at, created_at_absn, created_at_osn, created_at_tx_id, created_at_ledger
+        FROM vdr_entries
+        WHERE event_hash = ${root}
+        UNION ALL
+        SELECT e.event_hash, e.did_suffix, e.nonce, e.data_type, e.data_bytes, e.data_ipfs, e.previous_event_hash, e.status,
+               e.created_at, e.created_at_absn, e.created_at_osn, e.created_at_tx_id, e.created_at_ledger
+        FROM vdr_entries e
+        JOIN chain c ON e.previous_event_hash = c.event_hash
+      )
+      SELECT event_hash, did_suffix, nonce, data_type, data_bytes, data_ipfs, previous_event_hash, status,
+             created_at, created_at_absn, created_at_osn, created_at_tx_id, created_at_ledger
+      FROM chain
+      ORDER BY created_at DESC, created_at_absn DESC, created_at_osn DESC
+      LIMIT 1
+      """.stripMargin.query[VdrEntryRow].option
+
+  /** Walk backwards to the root (the first entry for an entry_id). */
+  def findRootOf(hash: Sha256Hash): ConnectionIO[Option[Sha256Hash]] =
+    sql"""
+      WITH RECURSIVE parents AS (
+        SELECT event_hash, previous_event_hash
+        FROM vdr_entries
+        WHERE event_hash = ${hash}
+        UNION ALL
+        SELECT e.event_hash, e.previous_event_hash
+        FROM vdr_entries e
+        JOIN parents p ON e.event_hash = p.previous_event_hash
+      )
+      SELECT event_hash
+      FROM parents
+      WHERE previous_event_hash IS NULL
+      LIMIT 1
+      """.stripMargin.query[Sha256Hash].option
 }

--- a/src/main/scala/io/iohk/atala/prism/node/repositories/daos/VdrEntriesDAO.scala
+++ b/src/main/scala/io/iohk/atala/prism/node/repositories/daos/VdrEntriesDAO.scala
@@ -15,6 +15,7 @@ import java.time.Instant
 object VdrEntriesDAO {
 
   case class VdrEntryRow(
+      entryId: Sha256Hash,
       eventHash: Sha256Hash,
       didSuffix: DidSuffix,
       nonce: Option[Array[Byte]],
@@ -31,6 +32,7 @@ object VdrEntriesDAO {
   )
 
   def insert(
+      entryId: Sha256Hash,
       eventHash: Sha256Hash,
       didSuffix: DidSuffix,
       nonce: Option[Array[Byte]],
@@ -43,10 +45,10 @@ object VdrEntriesDAO {
   ): ConnectionIO[Unit] = {
     val ts = ledgerData.timestampInfo
     sql"""INSERT INTO vdr_entries(
-         | event_hash, did_suffix, nonce, data_type, data_bytes, data_ipfs, previous_event_hash, status,
+         | entry_id, event_hash, did_suffix, nonce, data_type, data_bytes, data_ipfs, previous_event_hash, status,
          | created_at, created_at_absn, created_at_osn, created_at_tx_id, created_at_ledger
          |) VALUES (
-         | ${eventHash.bytes}, $didSuffix, $nonce, $dataType, $dataBytes, $dataIpfs, $previousEventHash, $status,
+         | ${entryId.bytes}, ${eventHash.bytes}, $didSuffix, $nonce, $dataType, $dataBytes, $dataIpfs, $previousEventHash, $status,
          | ${ts.atalaBlockTimestamp.toInstant}, ${ts.atalaBlockSequenceNumber}, ${ts.operationSequenceNumber},
          | ${ledgerData.transactionId}, ${ledgerData.ledger}
          |)
@@ -56,6 +58,7 @@ object VdrEntriesDAO {
   private implicit val vdrEntryRead: Read[VdrEntryRow] = {
     Read[
       (
+          Sha256Hash,
           Sha256Hash,
           DidSuffix,
           Option[Array[Byte]],
@@ -70,13 +73,29 @@ object VdrEntriesDAO {
           TransactionId,
           Ledger
       )
-    ].map { case (hash, did, nonce, dataType, dataBytes, dataIpfs, prevHash, status, ts, absn, osn, txId, ledger) =>
-      VdrEntryRow(hash, did, nonce, dataType, dataBytes, dataIpfs, prevHash, status, ts, absn, osn, txId, ledger)
+    ].map {
+      case (entryId, hash, did, nonce, dataType, dataBytes, dataIpfs, prevHash, status, ts, absn, osn, txId, ledger) =>
+        VdrEntryRow(
+          entryId,
+          hash,
+          did,
+          nonce,
+          dataType,
+          dataBytes,
+          dataIpfs,
+          prevHash,
+          status,
+          ts,
+          absn,
+          osn,
+          txId,
+          ledger
+        )
     }
   }
 
   def find(eventHash: Sha256Hash): ConnectionIO[Option[VdrEntryRow]] =
-    sql"""SELECT event_hash, did_suffix, nonce, data_type, data_bytes, data_ipfs, previous_event_hash, status,
+    sql"""SELECT entry_id, event_hash, did_suffix, nonce, data_type, data_bytes, data_ipfs, previous_event_hash, status,
           |       created_at, created_at_absn, created_at_osn, created_at_tx_id, created_at_ledger
           |FROM vdr_entries
           |WHERE event_hash = ${eventHash}
@@ -99,46 +118,9 @@ object VdrEntriesDAO {
       .query[(Sha256Hash, VdrEntryStatus)]
       .option
 
-  /** Walk the chain from a given event hash forward and return the latest descendant. Depth ordering avoids ties on
-    * timestamps when multiple events are created in the same block.
-    */
-  def findLatestFrom(root: Sha256Hash): ConnectionIO[Option[VdrEntryRow]] =
-    sql"""
-      WITH RECURSIVE chain AS (
-        SELECT event_hash, did_suffix, nonce, data_type, data_bytes, data_ipfs, previous_event_hash, status,
-               created_at, created_at_absn, created_at_osn, created_at_tx_id, created_at_ledger,
-               0 AS depth
-        FROM vdr_entries
-        WHERE event_hash = ${root}
-        UNION ALL
-        SELECT e.event_hash, e.did_suffix, e.nonce, e.data_type, e.data_bytes, e.data_ipfs, e.previous_event_hash, e.status,
-               e.created_at, e.created_at_absn, e.created_at_osn, e.created_at_tx_id, e.created_at_ledger,
-               c.depth + 1 AS depth
-        FROM vdr_entries e
-        JOIN chain c ON e.previous_event_hash = c.event_hash
-      )
-      SELECT event_hash, did_suffix, nonce, data_type, data_bytes, data_ipfs, previous_event_hash, status,
-             created_at, created_at_absn, created_at_osn, created_at_tx_id, created_at_ledger
-      FROM chain
-      ORDER BY depth DESC, created_at DESC, created_at_absn DESC, created_at_osn DESC
-      LIMIT 1
-      """.stripMargin.query[VdrEntryRow].option
-
-  /** Walk backwards to the root (the first entry for an entry_id). */
+  /** Resolve the chain identifier (root hash) for any event hash. */
   def findRootOf(hash: Sha256Hash): ConnectionIO[Option[Sha256Hash]] =
-    sql"""
-      WITH RECURSIVE parents AS (
-        SELECT event_hash, previous_event_hash
-        FROM vdr_entries
-        WHERE event_hash = ${hash}
-        UNION ALL
-        SELECT e.event_hash, e.previous_event_hash
-        FROM vdr_entries e
-        JOIN parents p ON e.event_hash = p.previous_event_hash
-      )
-      SELECT event_hash
-      FROM parents
-      WHERE previous_event_hash IS NULL
-      LIMIT 1
-      """.stripMargin.query[Sha256Hash].option
+    sql"""SELECT entry_id FROM vdr_entries WHERE event_hash = ${hash}""".stripMargin
+      .query[Sha256Hash]
+      .option
 }

--- a/src/main/scala/io/iohk/atala/prism/node/repositories/daos/VdrEntriesDAO.scala
+++ b/src/main/scala/io/iohk/atala/prism/node/repositories/daos/VdrEntriesDAO.scala
@@ -99,24 +99,28 @@ object VdrEntriesDAO {
       .query[(Sha256Hash, VdrEntryStatus)]
       .option
 
-  /** Walk the chain from a given event hash forward and return the latest event (by created_at). */
+  /** Walk the chain from a given event hash forward and return the latest descendant. Depth ordering avoids ties on
+    * timestamps when multiple events are created in the same block.
+    */
   def findLatestFrom(root: Sha256Hash): ConnectionIO[Option[VdrEntryRow]] =
     sql"""
       WITH RECURSIVE chain AS (
         SELECT event_hash, did_suffix, nonce, data_type, data_bytes, data_ipfs, previous_event_hash, status,
-               created_at, created_at_absn, created_at_osn, created_at_tx_id, created_at_ledger
+               created_at, created_at_absn, created_at_osn, created_at_tx_id, created_at_ledger,
+               0 AS depth
         FROM vdr_entries
         WHERE event_hash = ${root}
         UNION ALL
         SELECT e.event_hash, e.did_suffix, e.nonce, e.data_type, e.data_bytes, e.data_ipfs, e.previous_event_hash, e.status,
-               e.created_at, e.created_at_absn, e.created_at_osn, e.created_at_tx_id, e.created_at_ledger
+               e.created_at, e.created_at_absn, e.created_at_osn, e.created_at_tx_id, e.created_at_ledger,
+               c.depth + 1 AS depth
         FROM vdr_entries e
         JOIN chain c ON e.previous_event_hash = c.event_hash
       )
       SELECT event_hash, did_suffix, nonce, data_type, data_bytes, data_ipfs, previous_event_hash, status,
              created_at, created_at_absn, created_at_osn, created_at_tx_id, created_at_ledger
       FROM chain
-      ORDER BY created_at DESC, created_at_absn DESC, created_at_osn DESC
+      ORDER BY depth DESC, created_at DESC, created_at_absn DESC, created_at_osn DESC
       LIMIT 1
       """.stripMargin.query[VdrEntryRow].option
 

--- a/src/main/scala/io/iohk/atala/prism/node/services/NodeService.scala
+++ b/src/main/scala/io/iohk/atala/prism/node/services/NodeService.scala
@@ -168,16 +168,11 @@ private final class NodeServiceImpl[F[_]: MonadThrow](
         case Right(hash) =>
           vdrEntriesRepository
             .findLatest(hash)
-            .flatTap(entry =>
-              MonadThrow[F].catchNonFatal(
-                println(
-                  s"[vdr] latest lookup entryId=${hash.hexEncoded} resolved=${entry.map(e => (e.eventHash.hexEncoded, e.status))}"
-                )
-              )
-            )
             .map {
-              case Some(entry) => Right(toProtoVdrEntry(entry))
-              case None => Left(NodeError.UnknownValueError("vdr entry", hash.hexEncoded): NodeError)
+              case Some(entry) =>
+                Right(toProtoVdrEntry(entry))
+              case None =>
+                Left(NodeError.UnknownValueError("vdr entry", hash.hexEncoded): NodeError)
             }
       }
 
@@ -228,6 +223,12 @@ private final class NodeServiceImpl[F[_]: MonadThrow](
         entry.previousEventHash.map(h => ByteString.copyFrom(h.bytes.toArray)).getOrElse(ByteString.EMPTY)
       )
       .withDeactivated(entry.status == VdrEntryStatus.DEACTIVATED)
+      .withStatus(
+        entry.status match {
+          case VdrEntryStatus.ACTIVE => node_api.VdrEntryStatus.ACTIVE
+          case VdrEntryStatus.DEACTIVATED => node_api.VdrEntryStatus.DEACTIVATED
+        }
+      )
       .withNonce(entry.nonce.map(ByteString.copyFrom).getOrElse(ByteString.EMPTY))
       .withData(toProtoStorageData(entry.data))
 }

--- a/src/main/scala/io/iohk/atala/prism/node/services/NodeService.scala
+++ b/src/main/scala/io/iohk/atala/prism/node/services/NodeService.scala
@@ -70,6 +70,7 @@ trait NodeService[F[_]] {
   def getCurrentProtocolVersion: F[ProtocolVersion]
 
   def getVdrEntry(eventHash: ByteString): F[Either[NodeError, node_api.VdrEntry]]
+  def getVdrEntryLatest(entryId: ByteString): F[Either[NodeError, node_api.VdrEntry]]
 
   def verifyVdrEntry(eventHash: ByteString): F[Either[NodeError, node_api.VerifyVdrEntryResponse]]
 }
@@ -151,6 +152,29 @@ private final class NodeServiceImpl[F[_]: MonadThrow](
         case Right(hash) =>
           vdrEntriesRepository
             .find(hash)
+            .map {
+              case Some(entry) => Right(toProtoVdrEntry(entry))
+              case None => Left(NodeError.UnknownValueError("vdr entry", hash.hexEncoded): NodeError)
+            }
+      }
+
+  override def getVdrEntryLatest(entryId: ByteString): F[Either[NodeError, node_api.VdrEntry]] =
+    Either
+      .catchNonFatal(Sha256Hash.fromBytes(entryId.toByteArray))
+      .leftMap(err => NodeError.InvalidArgument(err.getMessage): NodeError)
+      .pure[F]
+      .flatMap {
+        case Left(err) => Applicative[F].pure(Left(err))
+        case Right(hash) =>
+          vdrEntriesRepository
+            .findLatest(hash)
+            .flatTap(entry =>
+              MonadThrow[F].catchNonFatal(
+                println(
+                  s"[vdr] latest lookup entryId=${hash.hexEncoded} resolved=${entry.map(e => (e.eventHash.hexEncoded, e.status))}"
+                )
+              )
+            )
             .map {
               case Some(entry) => Right(toProtoVdrEntry(entry))
               case None => Left(NodeError.UnknownValueError("vdr entry", hash.hexEncoded): NodeError)

--- a/src/main/scala/io/iohk/atala/prism/node/services/logs/NodeServiceLogging.scala
+++ b/src/main/scala/io/iohk/atala/prism/node/services/logs/NodeServiceLogging.scala
@@ -89,6 +89,18 @@ class NodeServiceLogging[F[_]: ServiceLogging[*[_], NodeService[F]]: MonadThrow]
       .onError(errorCause"encountered an error while $description" (_))
   }
 
+  override def getVdrEntryLatest(entryId: ByteString): Mid[F, Either[NodeError, node_api.VdrEntry]] = { in =>
+    val description = s"getting latest VDR entry for id ${entryId.toByteArray.map("%02X" format _).mkString}"
+    info"$description" *> in
+      .flatTap(
+        _.fold(
+          err => error"encountered an error while $description: $err",
+          _ => info"$description - done"
+        )
+      )
+      .onError(errorCause"encountered an error while $description" (_))
+  }
+
   override def verifyVdrEntry(eventHash: ByteString): Mid[F, Either[NodeError, node_api.VerifyVdrEntryResponse]] = {
     val description = s"verifying VDR entry ${eventHash.toByteArray.map("%02X" format _).mkString}"
     in =>

--- a/src/main/scala/io/iohk/atala/prism/node/services/logs/NodeServiceLogging.scala
+++ b/src/main/scala/io/iohk/atala/prism/node/services/logs/NodeServiceLogging.scala
@@ -83,7 +83,10 @@ class NodeServiceLogging[F[_]: ServiceLogging[*[_], NodeService[F]]: MonadThrow]
       .flatTap(
         _.fold(
           err => error"encountered an error while $description: $err",
-          _ => info"$description - done"
+          entry =>
+            info"$description - done (status=${entry.status.name}, deactivated=${entry.deactivated}, hash=${entry.eventHash.toByteArray
+                .map("%02X" format _)
+                .mkString}, prev=${entry.previousEventHash.toByteArray.map("%02X" format _).mkString})"
         )
       )
       .onError(errorCause"encountered an error while $description" (_))
@@ -95,7 +98,10 @@ class NodeServiceLogging[F[_]: ServiceLogging[*[_], NodeService[F]]: MonadThrow]
       .flatTap(
         _.fold(
           err => error"encountered an error while $description: $err",
-          _ => info"$description - done"
+          entry =>
+            info"$description - done (status=${entry.status.name}, deactivated=${entry.deactivated}, eventHash=${entry.eventHash.toByteArray
+                .map("%02X" format _)
+                .mkString}, prev=${entry.previousEventHash.toByteArray.map("%02X" format _).mkString})"
         )
       )
       .onError(errorCause"encountered an error while $description" (_))

--- a/src/main/scala/io/iohk/atala/prism/node/services/models/package.scala
+++ b/src/main/scala/io/iohk/atala/prism/node/services/models/package.scala
@@ -69,19 +69,28 @@ package object models {
       case CreateStorageEntryOperation(_, _, _, digest, _) =>
         OperationOutput(
           OperationOutput.Result.CreateVdrEntryOutput(
-            node_api.CreateVdrEntryOutput(ByteString.copyFrom(digest.bytes.toArray))
+            node_api.CreateVdrEntryOutput(
+              eventHash = ByteString.copyFrom(digest.bytes.toArray),
+              entryId = ByteString.copyFrom(digest.bytes.toArray)
+            )
           )
         )
       case UpdateStorageEntryOperation(_, _, digest, _) =>
         OperationOutput(
           OperationOutput.Result.UpdateVdrEntryOutput(
-            node_api.UpdateVdrEntryOutput(ByteString.copyFrom(digest.bytes.toArray))
+            node_api.UpdateVdrEntryOutput(
+              eventHash = ByteString.copyFrom(digest.bytes.toArray),
+              entryId = ByteString.copyFrom(digest.bytes.toArray)
+            )
           )
         )
       case DeactivateStorageEntryOperation(_, digest, _) =>
         OperationOutput(
           OperationOutput.Result.DeactivateVdrEntryOutput(
-            node_api.DeactivateVdrEntryOutput().withEventHash(ByteString.copyFrom(digest.bytes.toArray))
+            node_api.DeactivateVdrEntryOutput(
+              eventHash = ByteString.copyFrom(digest.bytes.toArray),
+              entryId = ByteString.copyFrom(digest.bytes.toArray)
+            )
           )
         )
       case other =>

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration scan="false">
+  <!-- Keep test output minimal during tests. -->
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} %-5level [%logger{36}] - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <!-- Silence noisy libs during tests -->
+  <logger name="com.zaxxer.hikari" level="ERROR"/>
+  <logger name="org.flywaydb" level="WARN"/>
+  <logger name="org.testcontainers" level="WARN"/>
+  <logger name="io.iohk.atala.prism" level="WARN"/>
+
+  <root level="ERROR">
+    <appender-ref ref="STDOUT"/>
+  </root>
+</configuration>

--- a/src/test/scala/io/iohk/atala/prism/node/NodeServiceSpec.scala
+++ b/src/test/scala/io/iohk/atala/prism/node/NodeServiceSpec.scala
@@ -13,7 +13,8 @@ import io.iohk.atala.prism.node.crypto.CryptoTestUtils
 import io.iohk.atala.prism.node.crypto.CryptoUtils.Sha256Hash
 import io.iohk.atala.prism.node.logging.TraceId
 import io.iohk.atala.prism.node.logging.TraceId.IOWithTraceIdContext
-import io.iohk.atala.prism.node.models.{AtalaOperationId, DidSuffix, Ledger, TransactionId, VdrEntryStatus}
+import io.iohk.atala.prism.node.models.{AtalaOperationId, DidSuffix, Ledger, TransactionId}
+import io.iohk.atala.prism.node.models.{VdrEntryStatus => ModelVdrStatus}
 import io.iohk.atala.prism.node.errors.NodeError
 import io.iohk.atala.prism.node.grpc.ProtoCodecs
 import io.iohk.atala.prism.node.models._
@@ -74,7 +75,7 @@ class NodeServiceSpec
       ): IOWithTraceIdContext[Unit] = {
         vdrEntriesStore.put(
           eventHash,
-          VdrEntry(eventHash, didSuffix, Some(data), None, VdrEntryStatus.ACTIVE, nonce)
+          VdrEntry(eventHash, didSuffix, Some(data), None, ModelVdrStatus.ACTIVE, nonce)
         )
         ().pure[IOWithTraceIdContext]
       }
@@ -88,7 +89,7 @@ class NodeServiceSpec
       ): IOWithTraceIdContext[Unit] = {
         vdrEntriesStore.put(
           eventHash,
-          VdrEntry(eventHash, didSuffix, Some(data), Some(previousEventHash), VdrEntryStatus.ACTIVE, None)
+          VdrEntry(eventHash, didSuffix, Some(data), Some(previousEventHash), ModelVdrStatus.ACTIVE, None)
         )
         ().pure[IOWithTraceIdContext]
       }
@@ -101,7 +102,7 @@ class NodeServiceSpec
       ): IOWithTraceIdContext[Unit] = {
         vdrEntriesStore.put(
           eventHash,
-          VdrEntry(eventHash, didSuffix, None, Some(previousEventHash), VdrEntryStatus.DEACTIVATED, None)
+          VdrEntry(eventHash, didSuffix, None, Some(previousEventHash), ModelVdrStatus.DEACTIVATED, None)
         )
         ().pure[IOWithTraceIdContext]
       }
@@ -790,7 +791,7 @@ class NodeServiceSpec
           DidSuffix("didSuffix"),
           Some(StorageData.Bytes(payload.toVector)),
           None,
-          VdrEntryStatus.ACTIVE,
+          ModelVdrStatus.ACTIVE,
           Some("nonce".getBytes)
         )
       )
@@ -818,7 +819,7 @@ class NodeServiceSpec
           didSuffix,
           Some(StorageData.Bytes("v1".getBytes.toVector)),
           None,
-          VdrEntryStatus.ACTIVE,
+          ModelVdrStatus.ACTIVE,
           None
         )
       )
@@ -829,30 +830,24 @@ class NodeServiceSpec
           didSuffix,
           Some(StorageData.Bytes("v2".getBytes.toVector)),
           Some(rootHash),
-          VdrEntryStatus.ACTIVE,
+          ModelVdrStatus.ACTIVE,
           None
         )
       )
       vdrEntriesStore.put(
         deactivateHash,
-        VdrEntry(deactivateHash, didSuffix, None, Some(updateHash), VdrEntryStatus.DEACTIVATED, None)
+        VdrEntry(deactivateHash, didSuffix, None, Some(updateHash), ModelVdrStatus.DEACTIVATED, None)
       )
 
-      val latest = service
-        .getVdrEntry(
-          GetVdrEntryRequest()
-            .withEntryId(ByteString.copyFrom(rootHash.bytes.toArray))
-            .withLatest(true)
-        )
-        .entry
-        .value
-
-      latest.eventHash mustBe ByteString.copyFrom(deactivateHash.bytes.toArray)
-      latest.previousEventHash mustBe ByteString.copyFrom(updateHash.bytes.toArray)
-      latest.deactivated mustBe true
-      latest.data must not be empty
-      latest.data.value.getBytes mustBe ByteString.EMPTY
-      latest.data.value.getIpfsCid mustBe ""
+      val resp =
+        service
+          .getVdrEntry(
+            GetVdrEntryRequest()
+              .withEntryId(ByteString.copyFrom(rootHash.bytes.toArray))
+              .withLatest(true)
+          )
+      resp.entry.value.status mustBe node_api.VdrEntryStatus.DEACTIVATED
+      resp.entry.value.deactivated mustBe true
     }
 
     "verify VDR entry chains and report missing links" in {
@@ -860,11 +855,11 @@ class NodeServiceSpec
       val childHash = Sha256Hash.compute("child".getBytes)
       vdrEntriesStore.put(
         rootHash,
-        VdrEntry(rootHash, DidSuffix("didSuffix"), None, None, VdrEntryStatus.ACTIVE, None)
+        VdrEntry(rootHash, DidSuffix("didSuffix"), None, None, ModelVdrStatus.ACTIVE, None)
       )
       vdrEntriesStore.put(
         childHash,
-        VdrEntry(childHash, DidSuffix("didSuffix"), None, Some(rootHash), VdrEntryStatus.ACTIVE, None)
+        VdrEntry(childHash, DidSuffix("didSuffix"), None, Some(rootHash), ModelVdrStatus.ACTIVE, None)
       )
 
       val ok =

--- a/src/test/scala/io/iohk/atala/prism/node/NodeServiceSpec.scala
+++ b/src/test/scala/io/iohk/atala/prism/node/NodeServiceSpec.scala
@@ -108,6 +108,30 @@ class NodeServiceSpec
 
       override def find(eventHash: Sha256Hash): IOWithTraceIdContext[Option[VdrEntry]] =
         vdrEntriesStore.get(eventHash).pure[IOWithTraceIdContext]
+
+      override def findLatest(eventHash: Sha256Hash): IOWithTraceIdContext[Option[VdrEntry]] = {
+        // traverse the chain forward to the latest descendant
+        def next(current: Sha256Hash): Option[VdrEntry] =
+          vdrEntriesStore.values.find(_.previousEventHash.contains(current))
+
+        vdrEntriesStore.get(eventHash) match {
+          case None => Option.empty[VdrEntry].pure[IOWithTraceIdContext]
+          case Some(root) =>
+            var latest = root
+            var cursor = root
+            var cont = true
+            while (cont) {
+              next(cursor.eventHash) match {
+                case Some(n) =>
+                  latest = n
+                  cursor = n
+                case None =>
+                  cont = false
+              }
+            }
+            Option(latest).pure[IOWithTraceIdContext]
+        }
+      }
     }
 
     serverName = InProcessServerBuilder.generateName()
@@ -779,6 +803,56 @@ class NodeServiceSpec
       entry.deactivated mustBe false
       entry.nonce.toByteArray.toVector mustBe "nonce".getBytes.toVector
       entry.data.value.content mustBe node_models.StorageData.Content.Bytes(ByteString.copyFrom(payload))
+    }
+
+    "return latest VDR entry as deactivated when the chain ends with a deactivate event" in {
+      val didSuffix = DidSuffix("didSuffix")
+      val rootHash = Sha256Hash.compute("root-latest".getBytes)
+      val updateHash = Sha256Hash.compute("update-latest".getBytes)
+      val deactivateHash = Sha256Hash.compute("deactivate-latest".getBytes)
+
+      vdrEntriesStore.put(
+        rootHash,
+        VdrEntry(
+          rootHash,
+          didSuffix,
+          Some(StorageData.Bytes("v1".getBytes.toVector)),
+          None,
+          VdrEntryStatus.ACTIVE,
+          None
+        )
+      )
+      vdrEntriesStore.put(
+        updateHash,
+        VdrEntry(
+          updateHash,
+          didSuffix,
+          Some(StorageData.Bytes("v2".getBytes.toVector)),
+          Some(rootHash),
+          VdrEntryStatus.ACTIVE,
+          None
+        )
+      )
+      vdrEntriesStore.put(
+        deactivateHash,
+        VdrEntry(deactivateHash, didSuffix, None, Some(updateHash), VdrEntryStatus.DEACTIVATED, None)
+      )
+
+      val latest = service
+        .getVdrEntry(
+          GetVdrEntryRequest()
+            .withEntryId(ByteString.copyFrom(rootHash.bytes.toArray))
+            .withLatest(true)
+        )
+        .entry
+        .value
+
+      latest.eventHash mustBe ByteString.copyFrom(deactivateHash.bytes.toArray)
+      latest.previousEventHash mustBe ByteString.copyFrom(updateHash.bytes.toArray)
+      latest.deactivated mustBe true
+      latest.data must not be empty
+      latest.data.value.getBytes mustBe ByteString.EMPTY
+      latest.data.value.getIpfsCid mustBe ""
     }
 
     "verify VDR entry chains and report missing links" in {

--- a/src/test/scala/io/iohk/atala/prism/node/operations/StorageOperationsSpec.scala
+++ b/src/test/scala/io/iohk/atala/prism/node/operations/StorageOperationsSpec.scala
@@ -102,7 +102,11 @@ class StorageOperationsSpec extends AtalaWithPostgresSpec {
       val data = node_models.StorageData().withBytes(ByteString.copyFromUtf8("payload"))
       val op = StorageOperations.parseCreate(createStorageProto(data), dummyLedgerData).value
 
-      val res = op.getCorrectnessData("vdr").value.transact(database).unsafeRunSync()
+      val res = op
+        .getCorrectnessData(s"did:prism:${didSuffix.getValue}#vdr")
+        .value
+        .transact(database)
+        .unsafeRunSync()
 
       res.left.value mustBe EntityMissing("did suffix", didSuffix.getValue)
     }
@@ -113,7 +117,11 @@ class StorageOperationsSpec extends AtalaWithPostgresSpec {
       val data = node_models.StorageData().withBytes(ByteString.copyFromUtf8("payload"))
       val op = StorageOperations.parseCreate(createStorageProto(data), dummyLedgerData).value
 
-      val res = op.getCorrectnessData("master").value.transact(database).unsafeRunSync()
+      val res = op
+        .getCorrectnessData(s"did:prism:${didSuffix.getValue}#master")
+        .value
+        .transact(database)
+        .unsafeRunSync()
 
       res.left.value mustBe InvalidKeyUsed("VDR signing key")
     }
@@ -124,7 +132,11 @@ class StorageOperationsSpec extends AtalaWithPostgresSpec {
       val data = node_models.StorageData().withBytes(ByteString.copyFromUtf8("payload"))
       val op = StorageOperations.parseCreate(createStorageProto(data), dummyLedgerData).value
 
-      val res = op.getCorrectnessData("vdr").value.transact(database).unsafeRunSync()
+      val res = op
+        .getCorrectnessData(s"did:prism:${didSuffix.getValue}#vdr")
+        .value
+        .transact(database)
+        .unsafeRunSync()
 
       res.value.key.compressed.toVector mustBe vdrKeyPair.publicKey.compressed.toVector
     }
@@ -201,6 +213,35 @@ class StorageOperationsSpec extends AtalaWithPostgresSpec {
       val res = updateAfterDeactivate.getCorrectnessData("vdr").value.transact(database).unsafeRunSync()
 
       res.left.value mustBe InvalidPreviousOperation()
+    }
+
+    "update head status to DEACTIVATED when a deactivate operation is applied" in {
+      insertDid()
+      insertVdrKey()
+
+      val createOp = StorageOperations
+        .parseCreate(
+          createStorageProto(node_models.StorageData().withBytes(ByteString.copyFromUtf8("payload"))),
+          dummyLedgerData
+        )
+        .value
+      createOp.applyState(dummyApplyOperationConfig).value.transact(database).unsafeRunSync().value
+
+      val updateOp = StorageOperations
+        .parseUpdate(
+          updateStorageProto(createOp.digest, node_models.StorageData().withBytes(ByteString.copyFromUtf8("v2"))),
+          dummyLedgerData
+        )
+        .value
+      updateOp.applyState(dummyApplyOperationConfig).value.transact(database).unsafeRunSync().value
+
+      val deactivateOp =
+        StorageOperations.parseDeactivate(deactivateStorageProto(updateOp.digest), dummyLedgerData).value
+      deactivateOp.applyState(dummyApplyOperationConfig).value.transact(database).unsafeRunSync().value
+
+      val head = VdrEntriesDAO.findHead(createOp.digest).transact(database).unsafeRunSync().value
+      head._1 mustBe deactivateOp.digest
+      head._2 mustBe VdrEntryStatus.DEACTIVATED
     }
   }
 }

--- a/src/test/scala/io/iohk/atala/prism/node/repositories/daos/VdrEntriesDAOSpec.scala
+++ b/src/test/scala/io/iohk/atala/prism/node/repositories/daos/VdrEntriesDAOSpec.scala
@@ -26,6 +26,7 @@ class VdrEntriesDAOSpec extends AtalaWithPostgresSpec {
   private val eventHash = Sha256Hash.compute("event-1".getBytes)
   private val prevHash = Sha256Hash.compute("event-0".getBytes)
   private val deactivateHash = Sha256Hash.compute("event-2".getBytes)
+  private val updateHash = Sha256Hash.compute("event-1u".getBytes)
 
   override def beforeEach(): Unit = {
     super.beforeEach()
@@ -137,6 +138,93 @@ class VdrEntriesDAOSpec extends AtalaWithPostgresSpec {
       stored.dataBytes mustBe empty
       stored.dataIpfs mustBe empty
       stored.previousEventHash.value mustBe prevHash
+    }
+
+    "maintain head pointers for create/update/deactivate chain" in {
+      val root = Sha256Hash.compute("head-root".getBytes)
+      val update = Sha256Hash.compute("head-update".getBytes)
+      val deactivate = Sha256Hash.compute("head-deactivate".getBytes)
+
+      val insert = (hash: Sha256Hash, prev: Option[Sha256Hash], status: VdrEntryStatus, data: String) =>
+        VdrEntriesDAO
+          .insert(
+            hash,
+            didSuffix,
+            nonce = None,
+            dataType = "BYTES",
+            dataBytes = Some(data.getBytes),
+            dataIpfs = None,
+            previousEventHash = prev,
+            status = status,
+            ledgerData = ledgerData
+          )
+          .transact(database)
+          .unsafeRunSync()
+
+      insert(root, None, VdrEntryStatus.ACTIVE, "v1")
+      VdrEntriesDAO.insertHead(root, root, VdrEntryStatus.ACTIVE).transact(database).unsafeRunSync()
+
+      insert(update, Some(root), VdrEntryStatus.ACTIVE, "v2")
+      VdrEntriesDAO.updateHead(root, update, VdrEntryStatus.ACTIVE).transact(database).unsafeRunSync()
+
+      insert(deactivate, Some(update), VdrEntryStatus.DEACTIVATED, "")
+      VdrEntriesDAO.updateHead(root, deactivate, VdrEntryStatus.DEACTIVATED).transact(database).unsafeRunSync()
+
+      val head = VdrEntriesDAO.findHead(root).transact(database).unsafeRunSync().value
+      head._1 mustBe deactivate
+      head._2 mustBe VdrEntryStatus.DEACTIVATED
+    }
+
+    "findLatestFrom returns DEACTIVATED when the chain ends with a deactivate" in {
+      VdrEntriesDAO
+        .insert(
+          eventHash,
+          didSuffix,
+          nonce = None,
+          dataType = "BYTES",
+          dataBytes = Some("v1".getBytes),
+          dataIpfs = None,
+          previousEventHash = None,
+          status = VdrEntryStatus.ACTIVE,
+          ledgerData = ledgerData
+        )
+        .transact(database)
+        .unsafeRunSync()
+
+      VdrEntriesDAO
+        .insert(
+          updateHash,
+          didSuffix,
+          nonce = None,
+          dataType = "BYTES",
+          dataBytes = Some("v2".getBytes),
+          dataIpfs = None,
+          previousEventHash = Some(eventHash),
+          status = VdrEntryStatus.ACTIVE,
+          ledgerData = ledgerData
+        )
+        .transact(database)
+        .unsafeRunSync()
+
+      VdrEntriesDAO
+        .insert(
+          deactivateHash,
+          didSuffix,
+          nonce = None,
+          dataType = "NONE",
+          dataBytes = None,
+          dataIpfs = None,
+          previousEventHash = Some(updateHash),
+          status = VdrEntryStatus.DEACTIVATED,
+          ledgerData = ledgerData
+        )
+        .transact(database)
+        .unsafeRunSync()
+
+      // simulate head recomputation path
+      val latest = VdrEntriesDAO.findLatestFrom(eventHash).transact(database).unsafeRunSync().value
+      latest.eventHash mustBe deactivateHash
+      latest.status mustBe VdrEntryStatus.DEACTIVATED
     }
   }
 }

--- a/src/test/scala/io/iohk/atala/prism/node/repositories/daos/VdrEntriesDAOSpec.scala
+++ b/src/test/scala/io/iohk/atala/prism/node/repositories/daos/VdrEntriesDAOSpec.scala
@@ -26,7 +26,6 @@ class VdrEntriesDAOSpec extends AtalaWithPostgresSpec {
   private val eventHash = Sha256Hash.compute("event-1".getBytes)
   private val prevHash = Sha256Hash.compute("event-0".getBytes)
   private val deactivateHash = Sha256Hash.compute("event-2".getBytes)
-  private val updateHash = Sha256Hash.compute("event-1u".getBytes)
 
   override def beforeEach(): Unit = {
     super.beforeEach()
@@ -39,6 +38,7 @@ class VdrEntriesDAOSpec extends AtalaWithPostgresSpec {
 
       VdrEntriesDAO
         .insert(
+          eventHash,
           eventHash,
           didSuffix,
           nonce = Some("n1".getBytes),
@@ -67,6 +67,7 @@ class VdrEntriesDAOSpec extends AtalaWithPostgresSpec {
       VdrEntriesDAO
         .insert(
           prevHash,
+          prevHash,
           didSuffix,
           nonce = None,
           dataType = "BYTES",
@@ -81,6 +82,7 @@ class VdrEntriesDAOSpec extends AtalaWithPostgresSpec {
 
       VdrEntriesDAO
         .insert(
+          prevHash,
           eventHash,
           didSuffix,
           nonce = None,
@@ -106,6 +108,7 @@ class VdrEntriesDAOSpec extends AtalaWithPostgresSpec {
       VdrEntriesDAO
         .insert(
           prevHash,
+          prevHash,
           didSuffix,
           nonce = None,
           dataType = "BYTES",
@@ -120,6 +123,7 @@ class VdrEntriesDAOSpec extends AtalaWithPostgresSpec {
 
       VdrEntriesDAO
         .insert(
+          prevHash,
           deactivateHash,
           didSuffix,
           nonce = None,
@@ -148,6 +152,7 @@ class VdrEntriesDAOSpec extends AtalaWithPostgresSpec {
       val insert = (hash: Sha256Hash, prev: Option[Sha256Hash], status: VdrEntryStatus, data: String) =>
         VdrEntriesDAO
           .insert(
+            prev.getOrElse(hash),
             hash,
             didSuffix,
             nonce = None,
@@ -175,56 +180,5 @@ class VdrEntriesDAOSpec extends AtalaWithPostgresSpec {
       head._2 mustBe VdrEntryStatus.DEACTIVATED
     }
 
-    "findLatestFrom returns DEACTIVATED when the chain ends with a deactivate" in {
-      VdrEntriesDAO
-        .insert(
-          eventHash,
-          didSuffix,
-          nonce = None,
-          dataType = "BYTES",
-          dataBytes = Some("v1".getBytes),
-          dataIpfs = None,
-          previousEventHash = None,
-          status = VdrEntryStatus.ACTIVE,
-          ledgerData = ledgerData
-        )
-        .transact(database)
-        .unsafeRunSync()
-
-      VdrEntriesDAO
-        .insert(
-          updateHash,
-          didSuffix,
-          nonce = None,
-          dataType = "BYTES",
-          dataBytes = Some("v2".getBytes),
-          dataIpfs = None,
-          previousEventHash = Some(eventHash),
-          status = VdrEntryStatus.ACTIVE,
-          ledgerData = ledgerData
-        )
-        .transact(database)
-        .unsafeRunSync()
-
-      VdrEntriesDAO
-        .insert(
-          deactivateHash,
-          didSuffix,
-          nonce = None,
-          dataType = "NONE",
-          dataBytes = None,
-          dataIpfs = None,
-          previousEventHash = Some(updateHash),
-          status = VdrEntryStatus.DEACTIVATED,
-          ledgerData = ledgerData
-        )
-        .transact(database)
-        .unsafeRunSync()
-
-      // simulate head recomputation path
-      val latest = VdrEntriesDAO.findLatestFrom(eventHash).transact(database).unsafeRunSync().value
-      latest.eventHash mustBe deactivateHash
-      latest.status mustBe VdrEntryStatus.DEACTIVATED
-    }
   }
 }

--- a/src/test/scala/io/iohk/atala/prism/node/services/BlockProcessingServiceSpec.scala
+++ b/src/test/scala/io/iohk/atala/prism/node/services/BlockProcessingServiceSpec.scala
@@ -148,7 +148,7 @@ class BlockProcessingServiceSpec extends AtalaWithPostgresSpec {
             .withData(node_models.StorageData().withBytes(ByteString.copyFromUtf8("payload-1")))
         )
       val createDigest = Sha256Hash.compute(createOp.toByteArray)
-      val signedCreate = signOperation(createOp, "vdr", vdrKeys.privateKey)
+      val signedCreate = signOperation(createOp, s"did:prism:${didSuffix.getValue}#vdr", vdrKeys.privateKey)
 
       val updateOp = node_models
         .AtalaOperation()
@@ -159,7 +159,7 @@ class BlockProcessingServiceSpec extends AtalaWithPostgresSpec {
             .withData(node_models.StorageData().withIpfsCid("cid-2"))
         )
       val updateDigest = Sha256Hash.compute(updateOp.toByteArray)
-      val signedUpdate = signOperation(updateOp, "vdr", vdrKeys.privateKey)
+      val signedUpdate = signOperation(updateOp, s"did:prism:${didSuffix.getValue}#vdr", vdrKeys.privateKey)
 
       val deactivateOp = node_models
         .AtalaOperation()
@@ -169,7 +169,7 @@ class BlockProcessingServiceSpec extends AtalaWithPostgresSpec {
             .withPreviousEventHash(ByteString.copyFrom(updateDigest.bytes.toArray))
         )
       val deactivateDigest = Sha256Hash.compute(deactivateOp.toByteArray)
-      val signedDeactivate = signOperation(deactivateOp, "vdr", vdrKeys.privateKey)
+      val signedDeactivate = signOperation(deactivateOp, s"did:prism:${didSuffix.getValue}#vdr", vdrKeys.privateKey)
 
       val (objId, opIds) = DataPreparation.insertOperationStatuses(
         List(signedCreate, signedUpdate, signedDeactivate),


### PR DESCRIPTION
## Overview
- fixed the VDR driver implementation by introducing the VDR heads table where the latest entry in mapped to the initial hash
- added integration tests and documentation for the VDR driver
- reduced the loggin noise of the prism-node tests

## Checklists
- [x] documentation is added
- [x] integration tests are green

Pre-submit checklist:
- [x] Self-reviewed the diff
- [ ] New code has proper comments/documentation/tests
- [ ] Any changes not covered by tests have been tested manually
- [ ] The README files are updated
- [ ] If new libraries are included, they have licenses compatible with our project
- [ ] If there is a db migration altering existing tables, there is a proper migration test

Pre-merge checklist:
- [ ] Commits have useful messages
- [ ] Review clarifications made it into the code
