### PR TITLE
fix(vdr): reject VDR operations containing unknown protobuf fields

### DIFF
--- a/src/main/scala/io/iohk/atala/prism/node/operations/StorageOperations.scala
+++ b/src/main/scala/io/iohk/atala/prism/node/operations/StorageOperations.scala
@@ -19,6 +19,7 @@ import io.iohk.atala.prism.node.operations.StateError.{
 import io.iohk.atala.prism.node.operations.path._
 import io.iohk.atala.prism.node.repositories.daos.{DIDDataDAO, PublicKeysDAO, VdrEntriesDAO}
 import io.iohk.atala.prism.protos.node_models
+import scalapb.UnknownFieldSet
 import scala.util.Try
 
 sealed trait StorageOperation extends Operation {
@@ -257,6 +258,23 @@ object StorageOperations {
       )
       .toByteArray
 
+  /** Rejects a VDR operation if either the outer [[node_models.AtalaOperation]] wrapper or the inner storage operation
+    * message carries unknown protobuf fields.
+    *
+    * Unknown fields indicate a schema mismatch or a malformed/tampered message. For VDR operations strict validation is
+    * required to prevent two nodes running different protocol versions from diverging on stored state. SSI operations
+    * (CreateDID, UpdateDID, DeactivateDID) are intentionally left lenient for forward-compatibility.
+    */
+  private def ensureNoVdrUnknownFields(
+      outer: UnknownFieldSet,
+      inner: UnknownFieldSet
+  ): Either[ValidationError, Unit] =
+    Either.cond(
+      outer == UnknownFieldSet.empty && inner == UnknownFieldSet.empty,
+      (),
+      ValidationError.InvalidValue(Path.root, "unknown fields", "VDR operation contains unknown protobuf fields")
+    )
+
   private def parseCreateData(
       op: node_models.CreateStorageEntryOperation
   ): Either[ValidationError, StorageData] =
@@ -287,6 +305,7 @@ object StorageOperations {
   ): Either[ValidationError, CreateStorageEntryOperation] = {
     val create = ValueAtPath(operation, Path.root).child(_.getCreateStorageEntry, "createStorageEntry")
     for {
+      _ <- ensureNoVdrUnknownFields(operation.unknownFields, create.value.unknownFields)
       didHashBytes <- create.child(_.didPrismHash, "didPrismHash").parse { bytes =>
         Try(Sha256Hash.fromBytes(bytes.toByteArray)).toEither.leftMap(_ => "Invalid did_prism_hash")
       }
@@ -303,6 +322,7 @@ object StorageOperations {
   ): Either[ValidationError, UpdateStorageEntryOperation] = {
     val update = ValueAtPath(operation, Path.root).child(_.getUpdateStorageEntry, "updateStorageEntry")
     for {
+      _ <- ensureNoVdrUnknownFields(operation.unknownFields, update.value.unknownFields)
       prevHash <- update.child(_.previousEventHash, "previousEventHash").parse { bytes =>
         Try(Sha256Hash.fromBytes(bytes.toByteArray)).toEither.leftMap(_ => "Invalid previous_event_hash")
       }
@@ -317,6 +337,7 @@ object StorageOperations {
   ): Either[ValidationError, DeactivateStorageEntryOperation] = {
     val deactivate = ValueAtPath(operation, Path.root).child(_.getDeactivateStorageEntry, "deactivateStorageEntry")
     for {
+      _ <- ensureNoVdrUnknownFields(operation.unknownFields, deactivate.value.unknownFields)
       prevHash <- deactivate.child(_.previousEventHash, "previousEventHash").parse { bytes =>
         Try(Sha256Hash.fromBytes(bytes.toByteArray)).toEither.leftMap(_ => "Invalid previous_event_hash")
       }

--- a/src/test/scala/io/iohk/atala/prism/node/operations/StorageOperationsSpec.scala
+++ b/src/test/scala/io/iohk/atala/prism/node/operations/StorageOperationsSpec.scala
@@ -14,6 +14,7 @@ import io.iohk.atala.prism.node.repositories.daos.{DIDDataDAO, PublicKeysDAO, Vd
 import io.iohk.atala.prism.protos.node_models
 import org.scalatest.EitherValues._
 import org.scalatest.OptionValues._
+import scalapb.UnknownFieldSet
 
 class StorageOperationsSpec extends AtalaWithPostgresSpec {
 
@@ -77,6 +78,12 @@ class StorageOperationsSpec extends AtalaWithPostgresSpec {
           .DeactivateStorageEntryOperation()
           .withPreviousEventHash(ByteString.copyFrom(previous.bytes.toArray))
       )
+
+  // Field number 100 is used as the injected unknown field in all unknown-fields tests below.
+  // 100 is well above the highest field number used in any current proto schema,
+  // so it is guaranteed to be unknown to the current implementation.
+  private val unknownFieldSet =
+    UnknownFieldSet.empty.withField(100, UnknownFieldSet.Field(varint = Seq(0L)))
 
   "StorageOperations.parseCreate" should {
     "extract bytes payload, nonce and digest" in {
@@ -289,6 +296,58 @@ class StorageOperationsSpec extends AtalaWithPostgresSpec {
       val head = VdrEntriesDAO.findHead(createOp.digest).transact(database).unsafeRunSync().value
       head._1 mustBe deactivateOp.digest
       head._2 mustBe VdrEntryStatus.DEACTIVATED
+    }
+  }
+
+  "StorageOperations unknown field validation" should {
+    "reject parseCreate when inner message has unknown protobuf fields" in {
+      val data = node_models.CreateStorageEntryOperation.Data.Bytes(ByteString.copyFromUtf8("payload"))
+      val proto = node_models
+        .AtalaOperation()
+        .withCreateStorageEntry(
+          node_models
+            .CreateStorageEntryOperation()
+            .withDidPrismHash(ByteString.copyFrom(didHash.bytes.toArray))
+            .withData(data)
+            .withUnknownFields(unknownFieldSet)
+        )
+
+      StorageOperations.parseCreate(proto, dummyLedgerData).left.value mustBe a[ValidationError.InvalidValue]
+    }
+
+    "reject parseCreate when outer AtalaOperation wrapper has unknown protobuf fields" in {
+      val data = node_models.CreateStorageEntryOperation.Data.Bytes(ByteString.copyFromUtf8("payload"))
+      val proto = createStorageProto(data).withUnknownFields(unknownFieldSet)
+
+      StorageOperations.parseCreate(proto, dummyLedgerData).left.value mustBe a[ValidationError.InvalidValue]
+    }
+
+    "reject parseUpdate when inner message has unknown protobuf fields" in {
+      val previous = Sha256Hash.compute("previous".getBytes)
+      val proto = node_models
+        .AtalaOperation()
+        .withUpdateStorageEntry(
+          node_models
+            .UpdateStorageEntryOperation()
+            .withPreviousEventHash(ByteString.copyFrom(previous.bytes.toArray))
+            .withUnknownFields(unknownFieldSet)
+        )
+
+      StorageOperations.parseUpdate(proto, dummyLedgerData).left.value mustBe a[ValidationError.InvalidValue]
+    }
+
+    "reject parseDeactivate when inner message has unknown protobuf fields" in {
+      val previous = Sha256Hash.compute("previous".getBytes)
+      val proto = node_models
+        .AtalaOperation()
+        .withDeactivateStorageEntry(
+          node_models
+            .DeactivateStorageEntryOperation()
+            .withPreviousEventHash(ByteString.copyFrom(previous.bytes.toArray))
+            .withUnknownFields(unknownFieldSet)
+        )
+
+      StorageOperations.parseDeactivate(proto, dummyLedgerData).left.value mustBe a[ValidationError.InvalidValue]
     }
   }
 }


### PR DESCRIPTION
## Summary

Fixes #890

VDR storage operations (`CreateStorageEntry`, `UpdateStorageEntry`, `DeactivateStorageEntry`) that carry unknown protobuf fields are now rejected with a `ValidationError` during parsing.

This mirrors the fix applied to neoprism in [hyperledger-identus/neoprism#237](https://github.com/hyperledger-identus/neoprism/pull/237).

## Motivation

Unknown fields in a protobuf message indicate either a schema mismatch or a malformed/tampered message. Accepting them silently could cause two nodes running different protocol versions to diverge on stored VDR state, since one node would accept an operation the other would reject once it receives a schema update.

SSI operations (`CreateDID`, `UpdateDID`, `DeactivateDID`) are intentionally left lenient so future protocol extensions remain forward-compatible. Only VDR operations require strict validation.

## Changes

**`StorageOperations.scala`**
- Added `import scalapb.UnknownFieldSet`
- Added private helper `ensureNoVdrUnknownFields(outer: UnknownFieldSet, inner: UnknownFieldSet)` that returns `Left(InvalidValue(...))` if either field set is non-empty
- Applied the guard as the first step in `parseCreate`, `parseUpdate`, and `parseDeactivate`, checking both the outer `AtalaOperation` wrapper and the inner storage operation message

**`StorageOperationsSpec.scala`**
- Added `import scalapb.UnknownFieldSet`
- Added a shared `unknownFieldSet` value (field 100, guaranteed above all current schema fields)
- Added 4 new tests:
  - `parseCreate` rejects unknown fields on the inner `CreateStorageEntryOperation` message
  - `parseCreate` rejects unknown fields on the outer `AtalaOperation` wrapper
  - `parseUpdate` rejects unknown fields on the inner `UpdateStorageEntryOperation` message
  - `parseDeactivate` rejects unknown fields on the inner `DeactivateStorageEntryOperation` message

## Test results

```
[info] Tests: succeeded 323, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
```